### PR TITLE
Remove qflex-base@docker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ before_script:
   - docker-compose build
 
 script:
-  - docker run -ti --rm qflex-tests:latest
+  - docker run -ti --rm qflex-cxx-tests:latest
   - docker run -ti --rm qflex-py-tests:latest
   - docker run -ti --rm qflex:latest /qflex/config/circuits/bristlecone_48_1-24-1_0.txt /qflex/config/ordering/bristlecone_48.txt /qflex/config/grid/bristlecone_48.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM ngnrsaa/cirq-alpine:latest
 
 # Install baseline
 RUN apk update
-RUN apk add git openssh g++ make gsl-dev git autoconf automake python3-dev py3-pybind11 py3-packaging py3-pytest py3-docopt
+RUN apk add git g++ make gsl-dev git autoconf automake python3-dev py3-pybind11 py3-packaging py3-pytest py3-docopt
 
-# Copy qflex
-COPY ./ /qflex/
+# Clone qflex
+RUN git clone --depth 1 --shallow-submodules https://github.com/ngnrsaa/qflex.git /qflex/
 
 WORKDIR /qflex/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ngnrsaa/cirq-alpine:latest
 
 # Install baseline
 RUN apk update
-RUN apk add g++ make gsl-dev git autoconf automake python3-dev py3-pybind11 py3-packaging py3-pytest py3-docopt
+RUN apk add git openssh g++ make gsl-dev git autoconf automake python3-dev py3-pybind11 py3-packaging py3-pytest py3-docopt
 
 # Copy qflex
 COPY ./ /qflex/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,8 @@ ARG QFLEX_BRANCH
 # Copy qflex
 COPY ./ /qflex
 
-## Clone qflex
-#RUN git clone --depth 1 --branch ${QFLEX_BRANCH:-master} --shallow-submodules ${QFLEX_REPO:-https://github.com/ngnrsaa/qflex.git} /qflex/
-
 # Move to the right folder
 WORKDIR /qflex/
-
-# Init submodules
-RUN git submodule init
 
 # Install dependences
 RUN autoreconf -i && autoconf && ./configure --disable-all_checks

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ WORKDIR /qflex/
 RUN autoreconf -i && autoconf && ./configure --disable-all_checks
 
 # Compile qflex
-RUN make -j${OMP_NUM_THREADS:-1}
+RUN make -j${OMP_NUM_THREADS:-4}
 
 ENTRYPOINT ["/qflex/src/qflex.x"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-# Base OS
-FROM dagart/cirq-alpine:latest
-
-# Install baseline
-RUN apk update
-RUN apk add g++ make gsl-dev git autoconf automake python3-dev py3-pybind11 py3-packaging py3-pytest py3-docopt
-
-ENTRYPOINT ["/bin/sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,12 @@ FROM ngnrsaa/cirq-alpine:latest
 RUN apk update
 RUN apk add git g++ make gsl-dev git autoconf automake python3-dev py3-pybind11 py3-packaging py3-pytest py3-docopt
 
+# Arguments from docker-compose
+ARG OMP_NUM_THREADS
+ARG QFLEX_BRANCH
+
 # Clone qflex
-RUN git clone --depth 1 --shallow-submodules https://github.com/ngnrsaa/qflex.git /qflex/
+RUN git clone --depth 1 --branch ${QFLEX_BRANCH:-master} --shallow-submodules ${QFLEX_REPO:-https://github.com/ngnrsaa/qflex.git} /qflex/
 
 WORKDIR /qflex/
 
@@ -14,6 +18,6 @@ WORKDIR /qflex/
 RUN autoreconf -i && autoconf && ./configure --disable-all_checks
 
 # Compile qflex
-RUN make -j${OMP_NUM_THREADS:-4}
+RUN make -j${OMP_NUM_THREADS:-8}
 
 ENTRYPOINT ["/qflex/src/qflex.x"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apk add git g++ make gsl-dev git autoconf automake python3-dev py3-pybind11 
 
 # Arguments from docker-compose
 ARG OMP_NUM_THREADS
-ARG QFLEX_BRANCH
 
 # Copy qflex
 COPY ./ /qflex

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,17 @@ RUN apk add git g++ make gsl-dev git autoconf automake python3-dev py3-pybind11 
 ARG OMP_NUM_THREADS
 ARG QFLEX_BRANCH
 
-# Clone qflex
-RUN git clone --depth 1 --branch ${QFLEX_BRANCH:-master} --shallow-submodules ${QFLEX_REPO:-https://github.com/ngnrsaa/qflex.git} /qflex/
+# Copy qflex
+COPY ./ /qflex
 
+## Clone qflex
+#RUN git clone --depth 1 --branch ${QFLEX_BRANCH:-master} --shallow-submodules ${QFLEX_REPO:-https://github.com/ngnrsaa/qflex.git} /qflex/
+
+# Move to the right folder
 WORKDIR /qflex/
+
+# Init submodules
+RUN git submodule init
 
 # Install dependences
 RUN autoreconf -i && autoconf && ./configure --disable-all_checks

--- a/Makefile.in
+++ b/Makefile.in
@@ -39,7 +39,7 @@ all: $(TARGETS)
 
 .PHONY: qflex
 qflex:
-	git submodule update --init --recursive src/docopt
+	git submodule init src/docopt
 	$(MAKE) -C src/
 
 .PHONY: pybind
@@ -48,7 +48,7 @@ pybind: qflex
 
 .PHONY: tests
 tests:
-	git submodule update --init --recursive tests/src/googletest
+	git submodule init tests/src/googletest
 	$(MAKE) -C tests/src/
 
 .PHONY: run-py-tests

--- a/Makefile.in
+++ b/Makefile.in
@@ -40,6 +40,7 @@ all: $(TARGETS)
 .PHONY: qflex
 qflex:
 	git submodule init src/docopt
+	git submodule update src/docopt
 	$(MAKE) -C src/
 
 .PHONY: pybind
@@ -49,6 +50,7 @@ pybind: qflex
 .PHONY: tests
 tests:
 	git submodule init tests/src/googletest
+	git submodule update tests/src/googletest
 	$(MAKE) -C tests/src/
 
 .PHONY: run-py-tests

--- a/Makefile.in
+++ b/Makefile.in
@@ -39,8 +39,7 @@ all: $(TARGETS)
 
 .PHONY: qflex
 qflex:
-	git submodule init src/docopt
-	git submodule update src/docopt
+	-git submodule update --init --recursive src/docopt
 	$(MAKE) -C src/
 
 .PHONY: pybind
@@ -49,8 +48,7 @@ pybind: qflex
 
 .PHONY: tests
 tests:
-	git submodule init tests/src/googletest
-	git submodule update tests/src/googletest
+	-git submodule update --init --recursive tests/src/googletest
 	$(MAKE) -C tests/src/
 
 .PHONY: run-py-tests

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ without having to worry about managing dependencies.
 
 To build qFlex with Docker, see [the Docker guide](/docs/docker.md).
 
+An automated qFlex Docker container, synced with the `master` branch, can be
+pulled from Docker Hub as:
+```
+$ docker pull ngnrsaa/qflex
+```
+
 ### Build Using Rootless Containers
 
 Rootless containers are an alternative to Docker targeted at users who may not

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,5 @@
 version: "3"
 services:
-  qflex-base:
-    image: qflex-base
-    container_name: qflex-base
-    build:
-      context: ./
-      dockerfile: Dockerfile
-    environment:
-      - OMP_NUM_THREADS=8
   qflex:
     image: qflex
     container_name: qflex
@@ -16,8 +8,6 @@ services:
       dockerfile: src/Dockerfile
     environment:
       - OMP_NUM_THREADS=8
-    depends_on:
-      - qflex-base
   qflex-tests:
     image: qflex-tests
     container_name: qflex-tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,16 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
-    environment:
-      - OMP_NUM_THREADS=8
-  qflex-tests:
-    image: qflex-tests
-    container_name: qflex-tests
+      args:
+        - OMP_NUM_THREADS=${OMP_NUM_THREADS}
+        - QFLEX_BRANCH=${QFLEX_BRANCH}
+        - QFLEX_REPO=${QFLEX_REPO}
+  qflex-cxx-tests:
+    image: qflex-cxx-tests
+    container_name: qflex-cxx-tests
     build:
       context: ./
       dockerfile: tests/src/Dockerfile
-    environment:
-      - OMP_NUM_THREADS=8
     depends_on:
     - qflex
   qflex-py-tests:
@@ -24,7 +24,5 @@ services:
     build:
       context: ./
       dockerfile: tests/python/Dockerfile
-    environment:
-      - OMP_NUM_THREADS=8
     depends_on:
     - qflex

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: qflex
     build:
       context: ./
-      dockerfile: src/Dockerfile
+      dockerfile: Dockerfile
     environment:
       - OMP_NUM_THREADS=8
   qflex-tests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
       dockerfile: Dockerfile
       args:
         - OMP_NUM_THREADS=${OMP_NUM_THREADS}
-        - QFLEX_BRANCH=${QFLEX_BRANCH}
-        - QFLEX_REPO=${QFLEX_REPO}
   qflex-cxx-tests:
     image: qflex-cxx-tests
     container_name: qflex-cxx-tests

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -11,7 +11,7 @@ To build qFlex and run all the tests:
 # docker-compose up --build
 ```
 
-`docker-compose` will create three images: `qflex`, `qflex-tests`, and
+`docker-compose` will create three images: `qflex`, `qflex-cxx-tests`, and
 `qflex-py-tests`. To build qFlex images without running tests, use the
 following command:
 
@@ -21,10 +21,10 @@ following command:
 
 ## Run Tests
 
-Once `qflex-tests` is created, use the following command to run all C++ tests:
+Once `qflex-cxx-tests` is created, use the following command to run all C++ tests:
 
 ```
-# docker run -ti --rm qflex-tests
+# docker run -ti --rm qflex-cxx-tests
 ```
 
 Similarly, once `qflex-py-tests` is created the following command will run all

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 # Base OS
-FROM dagart/cirq-alpine:latest
+FROM ngnrsaa/cirq-alpine:latest
 
 # Install baseline
 RUN apk update
@@ -14,6 +14,6 @@ WORKDIR /qflex/
 RUN autoreconf -i && autoconf && ./configure --disable-all_checks
 
 # Compile qflex
-RUN make -j${OMP_NUM_THREADS}
+RUN make -j${OMP_NUM_THREADS:-1}
 
 ENTRYPOINT ["/qflex/src/qflex.x"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,9 @@
 # Base OS
-FROM qflex-base
+FROM dagart/cirq-alpine:latest
+
+# Install baseline
+RUN apk update
+RUN apk add g++ make gsl-dev git autoconf automake python3-dev py3-pybind11 py3-packaging py3-pytest py3-docopt
 
 # Copy qflex
 COPY ./ /qflex/

--- a/tests/python/Dockerfile
+++ b/tests/python/Dockerfile
@@ -8,4 +8,4 @@ COPY ./tests/python/ /qflex/tests/python/
 # Compile tests
 WORKDIR /qflex/
 
-ENTRYPOINT make -j${OMP_NUM_THREADS} run-py-tests
+ENTRYPOINT make -j${OMP_NUM_THREADS:-4} run-py-tests

--- a/tests/python/Dockerfile
+++ b/tests/python/Dockerfile
@@ -3,7 +3,6 @@ FROM qflex
 
 # Arguments from docker-compose
 ARG OMP_NUM_THREADS
-ARG QFLEX_BRANCH
 
 # Compile tests
 WORKDIR /qflex/

--- a/tests/python/Dockerfile
+++ b/tests/python/Dockerfile
@@ -1,11 +1,11 @@
 # Use qFlex as baseline
 FROM qflex
 
-# Copy qflex tests
-COPY ./python/ /qflex/python/
-COPY ./tests/python/ /qflex/tests/python/
+# Arguments from docker-compose
+ARG OMP_NUM_THREADS
+ARG QFLEX_BRANCH
 
 # Compile tests
 WORKDIR /qflex/
 
-ENTRYPOINT make -j${OMP_NUM_THREADS:-4} run-py-tests
+ENTRYPOINT make -j${OMP_NUM_THREADS:-8} run-py-tests

--- a/tests/src/Dockerfile
+++ b/tests/src/Dockerfile
@@ -1,10 +1,11 @@
 # Use qFlex as baseline
 FROM qflex
 
-# Copy qflex tests
-COPY ./tests/src/ /qflex/tests/src/
+# Arguments from docker-compose
+ARG OMP_NUM_THREADS
+ARG QFLEX_BRANCH
 
 # Compile tests
 WORKDIR /qflex/
 
-ENTRYPOINT make -j${OMP_NUM_THREADS:-4} run-cxx-tests
+ENTRYPOINT make -j${OMP_NUM_THREADS:-8} run-cxx-tests

--- a/tests/src/Dockerfile
+++ b/tests/src/Dockerfile
@@ -3,7 +3,6 @@ FROM qflex
 
 # Arguments from docker-compose
 ARG OMP_NUM_THREADS
-ARG QFLEX_BRANCH
 
 # Compile tests
 WORKDIR /qflex/

--- a/tests/src/Dockerfile
+++ b/tests/src/Dockerfile
@@ -7,4 +7,4 @@ COPY ./tests/src/ /qflex/tests/src/
 # Compile tests
 WORKDIR /qflex/
 
-ENTRYPOINT make -j${OMP_NUM_THREADS} run-cxx-tests
+ENTRYPOINT make -j${OMP_NUM_THREADS:-4} run-cxx-tests


### PR DESCRIPTION
Fixes #214. To have automatic `docker` images, I need to remove the initial `qflex-base@docker`.

@alankao64: can you check that everything works? Thanks!