### PR TITLE
Fix circuit.load()

### DIFF
--- a/src/circuit.cpp
+++ b/src/circuit.cpp
@@ -28,7 +28,6 @@ void QflexCircuit::load(std::istream &istream) {
   this->load(std::move(istream));
 }
 void QflexCircuit::load(std::istream &&istream) {
-
   // Check if token is a number
   auto is_number = [](const std::string &token) {
     try {

--- a/src/circuit.cpp
+++ b/src/circuit.cpp
@@ -126,6 +126,9 @@ void QflexCircuit::load(std::istream &&istream) {
         this->gates.emplace_back();
         auto &gate = gates.back();
 
+        // Add raw line to gate
+        gate.raw = line;
+
         // Check the first token is actually a number
         if (not is_integer(tokens[0]))
           throw error_msg("First token must be a valid cycle number.");

--- a/src/circuit.cpp
+++ b/src/circuit.cpp
@@ -18,10 +18,18 @@ std::ostream &operator<<(std::ostream &out, const QflexGate &gate) {
   return gate.operator<<(out);
 }
 
+void QflexCircuit::clear() {
+  this->num_active_qubits = 0;
+  this->depth = 0;
+  gates.clear();
+}
+
 void QflexCircuit::load(std::istream &istream) {
   this->load(std::move(istream));
 }
 void QflexCircuit::load(std::istream &&istream) {
+
+  // Check if token is a number
   auto is_number = [](const std::string &token) {
     try {
       std::stol(token);
@@ -31,10 +39,12 @@ void QflexCircuit::load(std::istream &&istream) {
     return true;
   };
 
+  // Check if token is an integer
   auto is_integer = [&is_number](const std::string &token) {
     return is_number(token) and std::stol(token) == std::stod(token);
   };
 
+  // Given a line, strip everything that doesn't follow the right format
   auto strip_line = [](std::string line) {
     // Remove everything after '#'
     line = std::regex_replace(line, std::regex("#.*"), "");
@@ -63,6 +73,7 @@ void QflexCircuit::load(std::istream &&istream) {
     return line;
   };
 
+  // Given a line, tokenize it
   auto tokenize = [](const std::string &line,
                      const std::string &regex_expr = "[^\\s]+") {
     std::vector<std::string> tokens;
@@ -73,6 +84,9 @@ void QflexCircuit::load(std::istream &&istream) {
       tokens.push_back(w->str());
     return tokens;
   };
+
+  // Clear this circuit
+  this->clear();
 
   std::size_t line_counter{0}, last_cycle_number{0};
   std::unordered_set<std::size_t> used_qubits;

--- a/src/circuit.h
+++ b/src/circuit.h
@@ -26,6 +26,7 @@ struct QflexCircuit {
   std::size_t depth{0};
   std::vector<QflexGate> gates;
 
+  void clear();
   void load(std::istream &istream);
   void load(std::istream &&istream);
   void load(const std::string &filename);

--- a/src/circuit.h
+++ b/src/circuit.h
@@ -16,6 +16,7 @@ struct QflexGate {
   std::size_t cycle;
   std::vector<std::size_t> qubits;
   std::vector<double> params;
+  std::string raw;
 
   std::ostream &operator<<(std::ostream &out) const;
   friend std::ostream &operator<<(std::ostream &out, const QflexGate &gate);

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -9,7 +9,6 @@ void QflexGrid::clear() {
 }
 void QflexGrid::load(std::istream& istream) { this->load(std::move(istream)); }
 void QflexGrid::load(std::istream&& istream) {
-
   // Clear this grid
   this->clear();
 

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -2,9 +2,17 @@
 
 namespace qflex {
 
+void QflexGrid::clear() {
+  this->I = 0;
+  this->J = 0;
+  qubits_off.clear();
+}
 void QflexGrid::load(std::istream& istream) { this->load(std::move(istream)); }
 void QflexGrid::load(std::istream&& istream) {
-  I = J = 0;
+
+  // Clear this grid
+  this->clear();
+
   std::string line;
   while (std::getline(istream, line))
     if (std::size(line) and line[0] != '#') {

--- a/src/grid.h
+++ b/src/grid.h
@@ -10,6 +10,7 @@ namespace qflex {
 struct QflexGrid {
   int I{0}, J{0};
   std::vector<std::vector<int>> qubits_off;
+  void clear();
   void load(std::istream& istream);
   void load(std::istream&& istream);
   void load(const std::string& filename);

--- a/src/ordering.cpp
+++ b/src/ordering.cpp
@@ -2,15 +2,12 @@
 
 namespace qflex {
 
-void QflexOrdering::clear() {
-  this->instructions.clear();
-}
+void QflexOrdering::clear() { this->instructions.clear(); }
 
 void QflexOrdering::load(std::istream& istream) {
   this->load(std::move(istream));
 }
 void QflexOrdering::load(std::istream&& istream) {
-
   // Strip everthing from a line that doesn't follow the right format
   auto strip_line = [](std::string line) {
     // Remove everything after '#'

--- a/src/ordering.cpp
+++ b/src/ordering.cpp
@@ -2,10 +2,16 @@
 
 namespace qflex {
 
+void QflexOrdering::clear() {
+  this->instructions.clear();
+}
+
 void QflexOrdering::load(std::istream& istream) {
   this->load(std::move(istream));
 }
 void QflexOrdering::load(std::istream&& istream) {
+
+  // Strip everthing from a line that doesn't follow the right format
   auto strip_line = [](std::string line) {
     // Remove everything after '#'
     line = std::regex_replace(line, std::regex("#.*"), "");
@@ -33,11 +39,13 @@ void QflexOrdering::load(std::istream&& istream) {
     return line;
   };
 
+  // Clear this ordering
+  this->clear();
+
   std::string line;
   while (std::getline(istream, line))
     if (std::size(line = strip_line(line))) this->instructions.push_back(line);
 }
-
 void QflexOrdering::load(const std::string& filename) {
   if (auto in = std::ifstream(filename); in.good())
     this->load(in);

--- a/src/ordering.h
+++ b/src/ordering.h
@@ -10,6 +10,7 @@ namespace qflex {
 
 struct QflexOrdering {
   std::vector<std::string> instructions;
+  void clear();
   void load(std::istream& istream);
   void load(std::istream&& istream);
   void load(const std::string& filename);

--- a/src/read_circuit.cpp
+++ b/src/read_circuit.cpp
@@ -366,6 +366,15 @@ void circuit_data_to_tensor_network(
     idx += 1;
   }
 
+  // Check if off contains valid qubits
+  if (off.has_value())
+    for(const auto &w: off.value()) {
+      const auto &x = w[0];
+      const auto &y = w[1];
+      if (x < 0 or x >= I or y < 0 or y >= J)
+        throw ERROR_MSG("Off qubit '(", x, ", ", y, ")' is outside the grid.");
+    }
+
   std::unordered_set<int> used_qubits;
   std::size_t last_cycle{0};
   for (auto gate : circuit.gates) {

--- a/src/read_circuit.cpp
+++ b/src/read_circuit.cpp
@@ -396,8 +396,9 @@ void circuit_data_to_tensor_network(
       // Check that position is an active qubit
       bool qubit_off = find_grid_coord_in_list(off, i_j_1[0], i_j_1[1]);
       if (qubit_off)
-        throw ERROR_MSG("Qubit '", q1, "' in gate '", gate.cycle, " ", gate.name, " ",
-                          q1, "' must correspond to an active qubit.");
+        throw ERROR_MSG("Qubit '", q1, "' in gate '", gate.cycle, " ",
+                        gate.name, " ", q1,
+                        "' must correspond to an active qubit.");
 
       std::string input_name =
           "(" + std::to_string(i_j_1[0]) + "," + std::to_string(i_j_1[1]) +
@@ -414,7 +415,7 @@ void circuit_data_to_tensor_network(
         throw ERROR_MSG("Failed to call Tensor(). Error:\n\t[", err_msg, "]");
       }
 
-    // Two qubit gate
+      // Two qubit gate
     } else if (num_qubits == 2) {
       // Get qubits
       std::size_t q1 = gate.qubits[0];
@@ -427,11 +428,13 @@ void circuit_data_to_tensor_network(
       bool second_qubit_off = find_grid_coord_in_list(off, i_j_2[0], i_j_2[1]);
 
       if (first_qubit_off)
-        throw ERROR_MSG("Qubit '", q1, "' in gate '", gate.cycle, " ", gate.name, " ", q1, " ", q2,
-                         "' must correspond to an active qubit.");
+        throw ERROR_MSG("Qubit '", q1, "' in gate '", gate.cycle, " ",
+                        gate.name, " ", q1, " ", q2,
+                        "' must correspond to an active qubit.");
       if (second_qubit_off)
-        throw ERROR_MSG("Qubit '", q2, "' in gate '", gate.cycle, " ", gate.name, " ", q1, " ", q2,
-                         "' must correspond to an active qubit.");
+        throw ERROR_MSG("Qubit '", q2, "' in gate '", gate.cycle, " ",
+                        gate.name, " ", q1, " ", q2,
+                        "' must correspond to an active qubit.");
 
       bool nearest_neighbors =
           (std::abs(i_j_1[0] - i_j_2[0]) + std::abs(i_j_1[1] - i_j_2[1])) == 1;

--- a/src/read_circuit.cpp
+++ b/src/read_circuit.cpp
@@ -405,8 +405,7 @@ void circuit_data_to_tensor_network(
       // Check that position is an active qubit
       bool qubit_off = find_grid_coord_in_list(off, i_j_1[0], i_j_1[1]);
       if (qubit_off)
-        throw ERROR_MSG("Qubit '", q1, "' in gate '", gate.cycle, " ",
-                        gate.name, " ", q1,
+        throw ERROR_MSG("Qubit '", q1, "' in gate '", gate.raw,
                         "' must correspond to an active qubit.");
 
       std::string input_name =
@@ -437,12 +436,10 @@ void circuit_data_to_tensor_network(
       bool second_qubit_off = find_grid_coord_in_list(off, i_j_2[0], i_j_2[1]);
 
       if (first_qubit_off)
-        throw ERROR_MSG("Qubit '", q1, "' in gate '", gate.cycle, " ",
-                        gate.name, " ", q1, " ", q2,
+        throw ERROR_MSG("Qubit '", q1, "' in gate '", gate.raw,
                         "' must correspond to an active qubit.");
       if (second_qubit_off)
-        throw ERROR_MSG("Qubit '", q2, "' in gate '", gate.cycle, " ",
-                        gate.name, " ", q1, " ", q2,
+        throw ERROR_MSG("Qubit '", q2, "' in gate '", gate.raw,
                         "' must correspond to an active qubit.");
 
       bool nearest_neighbors =

--- a/src/read_circuit.cpp
+++ b/src/read_circuit.cpp
@@ -368,9 +368,9 @@ void circuit_data_to_tensor_network(
 
   // Check if off contains valid qubits
   if (off.has_value())
-    for(const auto &w: off.value()) {
-      const auto &x = w[0];
-      const auto &y = w[1];
+    for (const auto& w : off.value()) {
+      const auto& x = w[0];
+      const auto& y = w[1];
       if (x < 0 or x >= I or y < 0 or y >= J)
         throw ERROR_MSG("Off qubit '(", x, ", ", y, ")' is outside the grid.");
     }

--- a/src/read_circuit.cpp
+++ b/src/read_circuit.cpp
@@ -387,6 +387,7 @@ void circuit_data_to_tensor_network(
       else
         used_qubits.insert(q);
 
+    // One qubit gate
     if (std::size_t num_qubits = std::size(gate.qubits); num_qubits == 1) {
       // Get qubit
       std::size_t q1 = gate.qubits[0];
@@ -395,7 +396,8 @@ void circuit_data_to_tensor_network(
       // Check that position is an active qubit
       bool qubit_off = find_grid_coord_in_list(off, i_j_1[0], i_j_1[1]);
       if (qubit_off)
-        throw ERROR_MSG("Qubit ", q1, " must correspond to an active qubit.");
+        throw ERROR_MSG("Qubit '", q1, "' in gate '", gate.cycle, " ", gate.name, " ",
+                          q1, "' must correspond to an active qubit.");
 
       std::string input_name =
           "(" + std::to_string(i_j_1[0]) + "," + std::to_string(i_j_1[1]) +
@@ -412,6 +414,7 @@ void circuit_data_to_tensor_network(
         throw ERROR_MSG("Failed to call Tensor(). Error:\n\t[", err_msg, "]");
       }
 
+    // Two qubit gate
     } else if (num_qubits == 2) {
       // Get qubits
       std::size_t q1 = gate.qubits[0];
@@ -424,9 +427,11 @@ void circuit_data_to_tensor_network(
       bool second_qubit_off = find_grid_coord_in_list(off, i_j_2[0], i_j_2[1]);
 
       if (first_qubit_off)
-        throw ERROR_MSG("Qubit ", q1, " must correspond to an active qubit.");
+        throw ERROR_MSG("Qubit '", q1, "' in gate '", gate.cycle, " ", gate.name, " ", q1, " ", q2,
+                         "' must correspond to an active qubit.");
       if (second_qubit_off)
-        throw ERROR_MSG("Qubit ", q2, " must correspond to an active qubit.");
+        throw ERROR_MSG("Qubit '", q2, "' in gate '", gate.cycle, " ", gate.name, " ", q1, " ", q2,
+                         "' must correspond to an active qubit.");
 
       bool nearest_neighbors =
           (std::abs(i_j_1[0] - i_j_2[0]) + std::abs(i_j_1[1] - i_j_2[1])) == 1;

--- a/tests/src/read_circuit_test.cpp
+++ b/tests/src/read_circuit_test.cpp
@@ -120,7 +120,7 @@ TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
   } catch (std::string msg) {
     EXPECT_THAT(
         msg, testing::HasSubstr(
-                 "Qubit '0' in '1 t 0' must correspond to an active qubit."));
+                 "Qubit '0' in gate '1 t 0' must correspond to an active qubit."));
   }
 
   // Two qubit gate must have active qubit as first qubit input.
@@ -134,10 +134,23 @@ TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
     EXPECT_THAT(
         msg,
         testing::HasSubstr(
-            "Qubit '0' in '1 cz 0 1' must correspond to an active qubit."));
+            "Qubit '0' in gate '1 cz 0 1' must correspond to an active qubit."));
   }
 
   // Two qubit gate must have active qubit as second qubit input.
+  off_qubits = {{1, 0}};
+  try {
+    circuit_data_to_tensor_network(circuit, 2, 1, "0", "1", {}, off_qubits,
+                                   grid_of_tensors, scratch);
+    FAIL()
+        << "Expected circuit_data_to_tensor_network() to throw an exception.";
+  } catch (std::string msg) {
+    EXPECT_THAT(
+        msg, testing::HasSubstr(
+                 "Qubit '1' in gate '1 cz 0 1' must correspond to an active qubit"));
+  }
+
+  // Off qubit outside the grid
   off_qubits = {{0, 1}};
   try {
     circuit_data_to_tensor_network(circuit, 2, 1, "0", "1", {}, off_qubits,
@@ -147,7 +160,7 @@ TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
   } catch (std::string msg) {
     EXPECT_THAT(
         msg, testing::HasSubstr(
-                 "Qubit '1' in '1 cz 0 1' must correspond to an active qubit"));
+                 "Off qubit '(0, 1)' is outside the grid."));
   }
 }
 

--- a/tests/src/read_circuit_test.cpp
+++ b/tests/src/read_circuit_test.cpp
@@ -103,7 +103,6 @@ constexpr char kBadTGate[] = R"(1
 constexpr char kBadCzGate[] = R"(1
 1 cz 0 1)";
 
-// Broken test
 TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
   std::vector<std::vector<std::vector<Tensor>>> grid_of_tensors;
   std::vector<std::vector<int>> off_qubits = {{0, 0}};

--- a/tests/src/read_circuit_test.cpp
+++ b/tests/src/read_circuit_test.cpp
@@ -106,6 +106,7 @@ constexpr char kBadCzGate[] = R"(1
 constexpr char kBadCxGate[] = R"(1
 1 cx 0 1)";
 
+// Broken test
 TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
   std::vector<std::vector<std::vector<Tensor>>> grid_of_tensors;
   std::vector<std::vector<int>> off_qubits = {{0, 0}};

--- a/tests/src/read_circuit_test.cpp
+++ b/tests/src/read_circuit_test.cpp
@@ -103,9 +103,6 @@ constexpr char kBadTGate[] = R"(1
 constexpr char kBadCzGate[] = R"(1
 1 cz 0 1)";
 
-constexpr char kBadCxGate[] = R"(1
-1 cx 0 1)";
-
 // Broken test
 TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
   std::vector<std::vector<std::vector<Tensor>>> grid_of_tensors;
@@ -122,7 +119,7 @@ TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
         << "Expected circuit_data_to_tensor_network() to throw an exception.";
   } catch (std::string msg) {
     EXPECT_THAT(
-        msg, testing::HasSubstr("Qubit 0 must correspond to an active qubit."));
+        msg, testing::HasSubstr("Qubit '0' in '1 t 0' must correspond to an active qubit."));
   }
 
   // Two qubit gate must have active qubit as first qubit input.
@@ -134,23 +131,11 @@ TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
         << "Expected circuit_data_to_tensor_network() to throw an exception.";
   } catch (std::string msg) {
     EXPECT_THAT(
-        msg, testing::HasSubstr("Qubit 0 must correspond to an active qubit."));
-  }
-
-  // Two qubit gate must have active qubit as first qubit input.
-  circuit.load(std::stringstream(kBadCxGate));
-  try {
-    circuit_data_to_tensor_network(circuit, 2, 1, "0", "1", {}, off_qubits,
-                                   grid_of_tensors, scratch);
-    FAIL()
-        << "Expected circuit_data_to_tensor_network() to throw an exception.";
-  } catch (std::string msg) {
-    EXPECT_THAT(
-        msg, testing::HasSubstr("Qubit 0 must correspond to an active qubit."));
+        msg, testing::HasSubstr("Qubit '0' in '1 cz 0 1' must correspond to an active qubit."));
   }
 
   // Two qubit gate must have active qubit as second qubit input.
-  off_qubits = {{1, 0}};
+  off_qubits = {{0, 1}};
   try {
     circuit_data_to_tensor_network(circuit, 2, 1, "0", "1", {}, off_qubits,
                                    grid_of_tensors, scratch);
@@ -158,7 +143,7 @@ TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
         << "Expected circuit_data_to_tensor_network() to throw an exception.";
   } catch (std::string msg) {
     EXPECT_THAT(msg, testing::HasSubstr(
-                         "Qubit 0 has been used twice in the same cycle: 1"));
+                         "Qubit '1' in '1 cz 0 1' must correspond to an active qubit"));
   }
 }
 

--- a/tests/src/read_circuit_test.cpp
+++ b/tests/src/read_circuit_test.cpp
@@ -119,8 +119,9 @@ TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
         << "Expected circuit_data_to_tensor_network() to throw an exception.";
   } catch (std::string msg) {
     EXPECT_THAT(
-        msg, testing::HasSubstr(
-                 "Qubit '0' in gate '1 t 0' must correspond to an active qubit."));
+        msg,
+        testing::HasSubstr(
+            "Qubit '0' in gate '1 t 0' must correspond to an active qubit."));
   }
 
   // Two qubit gate must have active qubit as first qubit input.
@@ -131,10 +132,8 @@ TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
     FAIL()
         << "Expected circuit_data_to_tensor_network() to throw an exception.";
   } catch (std::string msg) {
-    EXPECT_THAT(
-        msg,
-        testing::HasSubstr(
-            "Qubit '0' in gate '1 cz 0 1' must correspond to an active qubit."));
+    EXPECT_THAT(msg, testing::HasSubstr("Qubit '0' in gate '1 cz 0 1' must "
+                                        "correspond to an active qubit."));
   }
 
   // Two qubit gate must have active qubit as second qubit input.
@@ -146,8 +145,9 @@ TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
         << "Expected circuit_data_to_tensor_network() to throw an exception.";
   } catch (std::string msg) {
     EXPECT_THAT(
-        msg, testing::HasSubstr(
-                 "Qubit '1' in gate '1 cz 0 1' must correspond to an active qubit"));
+        msg,
+        testing::HasSubstr(
+            "Qubit '1' in gate '1 cz 0 1' must correspond to an active qubit"));
   }
 
   // Off qubit outside the grid
@@ -158,9 +158,8 @@ TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
     FAIL()
         << "Expected circuit_data_to_tensor_network() to throw an exception.";
   } catch (std::string msg) {
-    EXPECT_THAT(
-        msg, testing::HasSubstr(
-                 "Off qubit '(0, 1)' is outside the grid."));
+    EXPECT_THAT(msg,
+                testing::HasSubstr("Off qubit '(0, 1)' is outside the grid."));
   }
 }
 

--- a/tests/src/read_circuit_test.cpp
+++ b/tests/src/read_circuit_test.cpp
@@ -119,7 +119,8 @@ TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
         << "Expected circuit_data_to_tensor_network() to throw an exception.";
   } catch (std::string msg) {
     EXPECT_THAT(
-        msg, testing::HasSubstr("Qubit '0' in '1 t 0' must correspond to an active qubit."));
+        msg, testing::HasSubstr(
+                 "Qubit '0' in '1 t 0' must correspond to an active qubit."));
   }
 
   // Two qubit gate must have active qubit as first qubit input.
@@ -131,7 +132,9 @@ TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
         << "Expected circuit_data_to_tensor_network() to throw an exception.";
   } catch (std::string msg) {
     EXPECT_THAT(
-        msg, testing::HasSubstr("Qubit '0' in '1 cz 0 1' must correspond to an active qubit."));
+        msg,
+        testing::HasSubstr(
+            "Qubit '0' in '1 cz 0 1' must correspond to an active qubit."));
   }
 
   // Two qubit gate must have active qubit as second qubit input.
@@ -142,8 +145,9 @@ TEST(ReadCircuitTest, CircuitReferencingInactiveQubits) {
     FAIL()
         << "Expected circuit_data_to_tensor_network() to throw an exception.";
   } catch (std::string msg) {
-    EXPECT_THAT(msg, testing::HasSubstr(
-                         "Qubit '1' in '1 cz 0 1' must correspond to an active qubit"));
+    EXPECT_THAT(
+        msg, testing::HasSubstr(
+                 "Qubit '1' in '1 cz 0 1' must correspond to an active qubit"));
   }
 }
 


### PR DESCRIPTION
Bug in circuit.load().

In read_circuit_test.cpp, ReadCircuitTest, CircuitReferencingInactiveQubits:
`circuit.load(std::stringstream(kBad_Gate))` is not updating the circuit, so `circuit_data_to_tensor_network()` is getting called on `kBadTGate` for all tests. 