### PR TITLE
Verbosity clean up

### DIFF
--- a/src/contraction_utils.cpp
+++ b/src/contraction_utils.cpp
@@ -160,7 +160,7 @@ ContractionData ContractionData::Initialize(
     alloc_size /= (1 << 10);
   }
 
-  if (global::verbose) {
+  if (global::verbose > 0) {
     int old_precision = std::cerr.precision(6);
     std::string suffix[] = {"B", "kB", "MB", "GB"};
     std::cerr << alloc_size << suffix[scale] << " allocated." << std::endl;
@@ -547,7 +547,7 @@ bool IsOrderingValid(const std::list<ContractionOperation>& ordering) {
 
   if (std::empty(error_msg)) return true;
 
-  if (global::verbose) std::cerr << error_msg << std::endl;
+  if (global::verbose > 0) std::cerr << error_msg << std::endl;
 
   return false;
 }

--- a/src/evaluate_circuit.cpp
+++ b/src/evaluate_circuit.cpp
@@ -107,7 +107,7 @@ std::vector<std::pair<std::string, std::complex<double>>> EvaluateCircuit(
   }
 
   std::chrono::high_resolution_clock::time_point t_output_0, t_output_1;
-  if (global::verbose) {
+  if (global::verbose > 0) {
     // Set precision for the printed floats.
     std::cerr.precision(12);
 
@@ -121,13 +121,13 @@ std::vector<std::pair<std::string, std::complex<double>>> EvaluateCircuit(
   // Reading input.
   const int super_dim = (int)pow(DIM, input->circuit.depth);
 
-  if (global::verbose) t0 = std::chrono::high_resolution_clock::now();
+  if (global::verbose > 0) t0 = std::chrono::high_resolution_clock::now();
 
   // Create the ordering for this tensor contraction from file.
   std::list<ContractionOperation> ordering;
   ordering_data_to_contraction_ordering(*input, &ordering);
 
-  if (global::verbose) {
+  if (global::verbose > 0) {
     t1 = std::chrono::high_resolution_clock::now();
     time_span =
         std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0);
@@ -148,7 +148,7 @@ std::vector<std::pair<std::string, std::complex<double>>> EvaluateCircuit(
   input->final_state =
       get_output_states(input, ordering, &final_qubits, &output_states);
 
-  if (global::verbose) t0 = std::chrono::high_resolution_clock::now();
+  if (global::verbose > 0) t0 = std::chrono::high_resolution_clock::now();
 
   // Scratch space to be reused for operations.
   // This scratch space is used for reading circuit and building tensor
@@ -156,7 +156,7 @@ std::vector<std::pair<std::string, std::complex<double>>> EvaluateCircuit(
   // when qubits are cut on the output index.
   s_type* scratch = new s_type[(int)pow(super_dim, 4) * 2];
 
-  if (global::verbose) {
+  if (global::verbose > 0) {
     t1 = std::chrono::high_resolution_clock::now();
     time_span =
         std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0);
@@ -171,7 +171,7 @@ std::vector<std::pair<std::string, std::complex<double>>> EvaluateCircuit(
   }
   // Scope so that the 3D grid of tensors is destructed.
   {
-    if (global::verbose) t0 = std::chrono::high_resolution_clock::now();
+    if (global::verbose > 0) t0 = std::chrono::high_resolution_clock::now();
 
     // Creating 3D grid of tensors from file.
     std::vector<std::vector<std::vector<Tensor>>> tensor_grid_3D;
@@ -180,7 +180,7 @@ std::vector<std::pair<std::string, std::complex<double>>> EvaluateCircuit(
                                    final_qubits, input->grid.qubits_off,
                                    tensor_grid_3D, scratch);
 
-    if (global::verbose) {
+    if (global::verbose > 0) {
       t1 = std::chrono::high_resolution_clock::now();
       time_span =
           std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0);
@@ -189,10 +189,10 @@ std::vector<std::pair<std::string, std::complex<double>>> EvaluateCircuit(
     }
 
     // Contract 3D grid onto 2D grid of tensors, as usual.
-    if (global::verbose) t0 = std::chrono::high_resolution_clock::now();
+    if (global::verbose > 0) t0 = std::chrono::high_resolution_clock::now();
     flatten_grid_of_tensors(tensor_grid_3D, tensor_grid, final_qubits,
                             input->grid.qubits_off, ordering, scratch);
-    if (global::verbose) {
+    if (global::verbose > 0) {
       t1 = std::chrono::high_resolution_clock::now();
       time_span =
           std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0);
@@ -214,7 +214,7 @@ std::vector<std::pair<std::string, std::complex<double>>> EvaluateCircuit(
   }
 
   // Final time
-  if (global::verbose) {
+  if (global::verbose > 0) {
     t_output_1 = std::chrono::high_resolution_clock::now();
     time_span = std::chrono::duration_cast<std::chrono::duration<double>>(
         t_output_1 - t_output_0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,8 +12,8 @@ static const char USAGE[] =
 tensor network, CPU-based simulator of large quantum circuits.
 
   Usage:
-    qflex <circuit_filename> <ordering_filename> <grid_filename> [<initial_conf> <final_conf>]
-    qflex -c <circuit_filename> -o <ordering_filename> -g <grid_filename> [--initial-conf <initial_conf> --final-conf <final_conf> --verbose --verbosity-level <level>]
+    qflex <circuit_filename> <ordering_filename> <grid_filename> [<initial_conf> <final_conf> --verbosity <verbosity_level>]
+    qflex -c <circuit_filename> -o <ordering_filename> -g <grid_filename> [--initial-conf <initial_conf> --final-conf <final_conf> --verbosity <verbosity_level>]
     qflex (-h | --help)
     qflex --version
 
@@ -22,8 +22,7 @@ tensor network, CPU-based simulator of large quantum circuits.
     -c,--circuit=<circuit_filename>        Circuit filename.
     -o,--ordering=<ordering_filename>      Ordering filename.
     -g,--grid=<grid_filename>              Grid filename.
-    -v,--verbose                           Verbose.
-    --verbosity-level=<level>              Verbosity level (default=1).
+    -v,--verbosity=<verbosity_level>       Verbosity level.
     --initial-conf=<initial_conf>          Initial configuration.
     --final-conf=<final_conf>              Final configuration.
     --version                              Show version.
@@ -44,13 +43,11 @@ int main(int argc, char** argv) {
     qflex::QflexInput input;
 
     // Update global qflex::global::verbose
-    if (bool(args["--verbose"]) and args["--verbose"].asBool()) {
-      qflex::global::verbose = 1;
-      if (bool(args["--verbosity-level"]))
-        if (const auto l = args["--verbosity-level"].asLong();
-            l > qflex::global::verbose)
-          qflex::global::verbose = l;
-    } else
+    if (bool(args["--verbosity"]))
+      qflex::global::verbose = args["--verbosity"].asLong();
+    else if (bool(args["<verbosity_level>"]))
+      qflex::global::verbose = args["<verbosity_level>"].asLong();
+    else
       qflex::global::verbose = 0;
 
     // Get initial/final configurations

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,32 +43,33 @@ int main(int argc, char** argv) {
     qflex::QflexInput input;
 
     // Update global qflex::global::verbose
-    if (bool(args["--verbosity"]))
+    if (static_cast<bool>(args["--verbosity"]))
       qflex::global::verbose = args["--verbosity"].asLong();
-    else if (bool(args["<verbosity_level>"]))
+    else if (static_cast<bool>(args["<verbosity_level>"]))
       qflex::global::verbose = args["<verbosity_level>"].asLong();
     else
       qflex::global::verbose = 0;
 
     // Get initial/final configurations
-    if (bool(args["--initial-conf"]))
+    if (static_cast<bool>(args["--initial-conf"]))
       input.initial_state = args["--initial-conf"].asString();
-    else if (bool(args["<initial_conf>"]))
+    else if (static_cast<bool>(args["<initial_conf>"]))
       input.initial_state = args["<initial_conf>"].asString();
 
-    if (bool(args["--final-conf"]))
+    if (static_cast<bool>(args["--final-conf"]))
       input.final_state = args["--final-conf"].asString();
-    else if (bool(args["<final_conf>"]))
+    else if (static_cast<bool>(args["<final_conf>"]))
       input.final_state = args["<final_conf>"].asString();
 
     // Getting filenames
-    std::string circuit_filename = bool(args["--circuit"])
+    std::string circuit_filename = static_cast<bool>(args["--circuit"])
                                        ? args["--circuit"].asString()
                                        : args["<circuit_filename>"].asString();
     std::string ordering_filename =
-        bool(args["--ordering"]) ? args["--ordering"].asString()
-                                 : args["<ordering_filename>"].asString();
-    std::string grid_filename = bool(args["--grid"])
+        static_cast<bool>(args["--ordering"])
+            ? args["--ordering"].asString()
+            : args["<ordering_filename>"].asString();
+    std::string grid_filename = static_cast<bool>(args["--grid"])
                                     ? args["--grid"].asString()
                                     : args["<grid_filename>"].asString();
 


### PR DESCRIPTION
Makes `--verbosity` flag work with positional arguments and simplifies to a single flag. (Previously both `--verbose` and `--verbosity-level` were required for verbosity > 1.)