### PR TITLE
Add --memory flag to prevent OOM failures.

### DIFF
--- a/src/contraction_utils.cpp
+++ b/src/contraction_utils.cpp
@@ -11,6 +11,22 @@
 
 namespace qflex {
 
+namespace {
+
+// Convert 'memory' bytes into a more readable string.
+std::string readable_memory_string(double memory) {
+  std::string suffix[] = {" B", " kB", " MB", " GB"};
+  std::size_t scale = 0;
+  double size_prefix = memory;
+  while (size_prefix >= (1 << 10)) {
+    ++scale;
+    size_prefix /= (1 << 10);
+  }
+  return concat(size_prefix, suffix[scale]);
+}
+
+}  // namespace
+
 // ContractionData methods
 
 ContractionData ContractionData::Initialize(
@@ -92,14 +108,56 @@ ContractionData ContractionData::Initialize(
     }
   }
 
-  long allocated_space = 0;
+  // Calculate the necessary space before actually allocating memory.
+
+  // If the --memory flag is set properly, this should prevent OOM errors.
+  uint64_t allocated_space = 0;
 
   // Max rank/size of all patches.
   int max_rank = 0;
   for (const auto& patch_rank_pair : data.patch_rank_) {
     max_rank = std::max(patch_rank_pair.second, max_rank);
   }
-  long unsigned int max_size = (long unsigned int)pow(bond_dim, max_rank);
+  uint64_t max_size = static_cast<uint64_t>(pow(bond_dim, max_rank));
+
+  // General-purpose scratch space (primarily used for tensor reordering).
+  allocated_space += max_size;
+
+  // "Swap tensor" space, used to store operation results.
+  for (int rank = 1; rank <= max_rank; ++rank) {
+    allocated_space += static_cast<uint64_t>(pow(bond_dim, rank));
+  }
+  // Per-patch space, sized to match the maximum size of the patch.
+  for (const auto& patch_rank_pair : data.patch_rank_) {
+    allocated_space +=
+        static_cast<uint64_t>(pow(bond_dim, patch_rank_pair.second));
+  }
+  // Extra space for storing copies made during cut operations.
+  for (const auto& copy_rank_pair : cut_copy_rank) {
+    allocated_space +=
+        static_cast<uint64_t>(pow(bond_dim, copy_rank_pair.second));
+  }
+
+  // Prevent memory allocation from exceeding memory_limit.
+  double alloc_size = allocated_space * sizeof(std::complex<double>);
+  if (alloc_size > global::memory_limit) {
+    throw ERROR_MSG("Required space (", readable_memory_string(alloc_size),
+                    ") exceeds memory limit (",
+                    readable_memory_string(global::memory_limit),
+                    "). Cancelling simulation.");
+  }
+
+  // Log how much space will be allocated for this operation. This includes all
+  // tensors allocated during contraction; total memory usage should not vary
+  // significantly from this value.
+  if (global::verbose > 0) {
+    int old_precision = std::cerr.precision(6);
+    std::cerr << "Allocating " << readable_memory_string(alloc_size)
+              << " for this simulation." << std::endl;
+    std::cerr.precision(old_precision);
+  }
+
+  // Actually allocate the required space.
 
   // General-purpose scratch space (primarily used for tensor reordering).
   try {
@@ -108,11 +166,10 @@ ContractionData ContractionData::Initialize(
     throw ERROR_MSG("Failed to call Tensor(). Error:\n\t[", err_msg, "]");
   }
   data.scratch_map_[kGeneralSpace] = 0;
-  allocated_space += max_size;
 
   // "Swap tensor" space, used to store operation results.
   for (int rank = 1; rank <= max_rank; ++rank) {
-    const long unsigned int size = (long unsigned int)pow(bond_dim, rank);
+    const uint64_t size = static_cast<uint64_t>(pow(bond_dim, rank));
     try {
       data.scratch_.push_back(Tensor({""}, {size}));
     } catch (const std::string& err_msg) {
@@ -122,10 +179,11 @@ ContractionData ContractionData::Initialize(
     allocated_space += size;
   }
 
+  // Per-patch space, sized to match the maximum size of the patch.
   int patch_pos = data.scratch_map_.size();
   for (const auto& patch_rank_pair : data.patch_rank_) {
-    const long unsigned int size =
-        (long unsigned int)pow(bond_dim, patch_rank_pair.second);
+    const uint64_t size =
+        static_cast<uint64_t>(pow(bond_dim, patch_rank_pair.second));
     try {
       data.scratch_.push_back(Tensor({""}, {size}));
     } catch (const std::string& err_msg) {
@@ -135,12 +193,13 @@ ContractionData ContractionData::Initialize(
     allocated_space += size;
   }
 
+  // Extra space for storing copies made during cut operations.
   // TODO(martinop): minor optimizations possible: When consecutive cuts apply
   // to the same grid tensor, only one copy needs to be stored.
   int cut_copy_pos = data.scratch_map_.size();
   for (const auto& copy_rank_pair : cut_copy_rank) {
-    const long unsigned int size =
-        (long unsigned int)pow(bond_dim, copy_rank_pair.second);
+    const uint64_t size =
+        static_cast<uint64_t>(pow(bond_dim, copy_rank_pair.second));
     try {
       data.scratch_.push_back(Tensor({""}, {size}));
     } catch (const std::string& err_msg) {
@@ -148,23 +207,6 @@ ContractionData ContractionData::Initialize(
     }
     data.scratch_map_[copy_rank_pair.first] = patch_pos++;
     allocated_space += size;
-  }
-
-  // Log how much space is allocated for this operation. This includes all
-  // tensors allocated during contraction; total memory usage should not vary
-  // significantly from this value.
-  int scale = 0;
-  double alloc_size = allocated_space * sizeof(std::complex<double>);
-  while (alloc_size > (1 << 10)) {
-    ++scale;
-    alloc_size /= (1 << 10);
-  }
-
-  if (global::verbose > 0) {
-    int old_precision = std::cerr.precision(6);
-    std::string suffix[] = {"B", "kB", "MB", "GB"};
-    std::cerr << alloc_size << suffix[scale] << " allocated." << std::endl;
-    std::cerr.precision(old_precision);
   }
 
   return data;

--- a/src/global.h
+++ b/src/global.h
@@ -6,7 +6,7 @@ namespace qflex::global {
 inline int verbose = 0;
 
 // Default limit of one gigabyte.
-inline uint64_t memory_limit = 1L << 30;
+inline std::size_t memory_limit = 1L << 30;
 
 }  // namespace qflex::global
 

--- a/src/global.h
+++ b/src/global.h
@@ -8,6 +8,6 @@ inline int verbose = 0;
 // Default limit of one gigabyte.
 inline uint64_t memory_limit = 1L << 30;
 
-}
+}  // namespace qflex::global
 
 #endif

--- a/src/global.h
+++ b/src/global.h
@@ -5,6 +5,9 @@ namespace qflex::global {
 
 inline int verbose = 0;
 
+// Default limit of one gigabyte.
+inline uint64_t memory_limit = 1L << 30;
+
 }
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,8 +12,8 @@ static const char USAGE[] =
 tensor network, CPU-based simulator of large quantum circuits.
 
   Usage:
-    qflex <circuit_filename> <ordering_filename> <grid_filename> [<initial_conf> <final_conf> --verbosity <verbosity_level>]
-    qflex -c <circuit_filename> -o <ordering_filename> -g <grid_filename> [--initial-conf <initial_conf> --final-conf <final_conf> --verbosity <verbosity_level>]
+    qflex <circuit_filename> <ordering_filename> <grid_filename> [<initial_conf> <final_conf> --verbosity <verbosity_level> --memory <memory_limit>]
+    qflex -c <circuit_filename> -o <ordering_filename> -g <grid_filename> [--initial-conf <initial_conf> --final-conf <final_conf> --verbosity <verbosity_level> --memory <memory_limit>]
     qflex (-h | --help)
     qflex --version
 
@@ -23,6 +23,7 @@ tensor network, CPU-based simulator of large quantum circuits.
     -o,--ordering=<ordering_filename>      Ordering filename.
     -g,--grid=<grid_filename>              Grid filename.
     -v,--verbosity=<verbosity_level>       Verbosity level.
+    -m,--memory=<memory_limit>             Memory limit (default 1GB).
     --initial-conf=<initial_conf>          Initial configuration.
     --final-conf=<final_conf>              Final configuration.
     --version                              Show version.
@@ -49,6 +50,15 @@ int main(int argc, char** argv) {
       qflex::global::verbose = args["<verbosity_level>"].asLong();
     else
       qflex::global::verbose = 0;
+
+    // Update global qflex::global::memory_limit
+    if (static_cast<bool>(args["--memory"]))
+      qflex::global::memory_limit = args["--memory"].asLong();
+    else if (static_cast<bool>(args["<memory_limit>"]))
+      qflex::global::memory_limit = args["<memory_limit>"].asLong();
+    else
+      // Default limit of one gigabyte.
+      qflex::global::memory_limit = 1L << 30;
 
     // Get initial/final configurations
     if (static_cast<bool>(args["--initial-conf"]))


### PR DESCRIPTION
Determine the required space before attempting to allocate it, and cancel the simulation if required space exceeds a user-specified limit (default 1GB). Try it out:
```
$ src/qflex.x config/circuits/bristlecone_48_1-24-1_0.txt config/ordering/bristlecone_48.txt config/grid/bristlecone_48.txt -m 20000000

# should return:
ERROR (contraction_utils.cpp: Initialize:145) --> Required space (106.799 MB) exceeds memory limit (19.0735 MB). Cancelling simulation.
```

Also replaced `long unsigned int` with `uint64_t`, since on some systems `long` will only use 32 bits.

This partially addresses #141, but does not fully resolve it (tensors larger than rank 32 will still cause issues until #225 is submitted).