### PR TITLE
Add fidelity controls to auto-ordering tool.

### DIFF
--- a/python/ordering/order_circuit_simulation.py
+++ b/python/ordering/order_circuit_simulation.py
@@ -320,8 +320,8 @@ def match_fidelity(target_fidelity: int, cuts: Dict[frozenset, int]):
             closest_set = width_set
             closest_fidelity = fidelity
 
-    return (closest_fidelity, zip(list(cuts.keys()), closest_set,
-                                  list(cuts.values())))
+    return (closest_fidelity,
+            zip(list(cuts.keys()), closest_set, list(cuts.values())))
 
 
 def circuit_to_ordering(
@@ -450,8 +450,10 @@ if __name__ == "__main__":
     if verbose:
         print('Compute ordering.', file=stderr)
 
-    ordering = circuit_to_ordering(circuit=circuit, qubit_names=sorted(qubits),
-                                   max_cuts=max_cuts, fidelity=fidelity)
+    ordering = circuit_to_ordering(circuit=circuit,
+                                   qubit_names=sorted(qubits),
+                                   max_cuts=max_cuts,
+                                   fidelity=fidelity)
     with (stdout
           if output_filename is None else open(output_filename, 'w')) as f:
         print('\n'.join(ordering), file=f)

--- a/python/ordering/order_circuit_simulation.py
+++ b/python/ordering/order_circuit_simulation.py
@@ -4,13 +4,15 @@ Provides a method for converting Cirq circuits to qFlex simulation order.
 
 Usage:
   order_circuit_simulation.py (-h | --help)
-  order_circuit_simulation.py <grid_filename> <circuit_filename>
-  order_circuit_simulation.py -g <grid_filename> -c <circuit_filename> [-v -o <output_file>]
+  order_circuit_simulation.py <grid_filename> <circuit_filename> [-v -x <cut_count> -f <fidelity_ratio> -o <output_file>]
+  order_circuit_simulation.py -g <grid_filename> -c <circuit_filename> [-v -x <cut_count> -f <fidelity_ratio> -o <output_file>]
 
 Options:
   -h, --help                           Show this help
   -g, --grid=<grid_filename>           Grid filename
   -c, --circuit=<circuit_filename>     Circuit filename
+  -x, --max_cuts=<cut_count>           Number of cuts to attempt [default: 2]
+  -f, --fidelity=<fidelity_ratio>      Circuit fidelity (enforced with cuts)
   -o, --output-file=<output_file>      Print on <output_file> instead of stdout
   -v, --verbose                        Verbose output
 """
@@ -18,7 +20,7 @@ Options:
 import itertools
 import math
 
-from typing import Iterable, Tuple
+from typing import Dict, Iterable, Tuple
 
 import cirq
 import os, sys
@@ -286,11 +288,48 @@ def get_steps_for_graph(g: Graph):
     return (time_cost, contraction_steps)
 
 
+def match_fidelity(target_fidelity: int, cuts: Dict[frozenset, int]):
+    '''Determines the "width" of each cut (what values to evaluate over) to
+    match the target fidelity as closely as possible.
+
+    Args:
+      target_fidelity: the requested fidelity. The final fidelity must be
+        greater than this, but should otherwise be as close as possible.
+      cuts: a dict of (cut_qubits, bond_dim) for all cuts.
+
+    Returns:
+      The final fidelity approximation and a list of tuples
+        (cut qubits, cut width, cut_dimension).
+'''
+    value_sets = []
+    denominator = 1.0
+    for cut, dim in cuts.items():
+        min_width = math.ceil(dim * target_fidelity)
+        value_sets.append(list(range(min_width, dim)))
+        denominator *= dim
+
+    combinations = itertools.product(*value_sets)
+    closest_set = []
+    closest_fidelity = 1.0
+    for width_set in combinations:
+        fidelity = 1.0
+        for width in width_set:
+            fidelity *= width
+        fidelity /= denominator
+        if fidelity > target_fidelity and fidelity < closest_fidelity:
+            closest_set = width_set
+            closest_fidelity = fidelity
+
+    return (closest_fidelity, zip(list(cuts.keys()), closest_set,
+                                  list(cuts.values())))
+
+
 def circuit_to_ordering(
     circuit: cirq.circuits.Circuit,
     qubit_names: Iterable[int] = None,
     qubit_order_method: cirq.ops.QubitOrderOrList = cirq.ops.QubitOrder.DEFAULT,
-    max_cuts: int = 2):
+    max_cuts: int = 2,
+    fidelity: float = 1.0):
     """Generates a qFlex circuit ordering (with cuts) from a Cirq circuit.
 
   Args:
@@ -302,6 +341,9 @@ def circuit_to_ordering(
     max_cuts: Maximum number of cuts attempted. Cuts are made using a greedy
       algorithm; making one or more cuts multiplies the time cost of this method
       by O(# of edges in circuit).
+    fidelity: If this is less than 1.0, cuts generated will only be evaluated
+      on a subset of the possible values. Subset size is controlled to provide
+      closest fidelity greater than the provided number.
 
   Returns:
     A list of string-formatted qFlex contraction commands (e.g. 'expand 1 2')
@@ -333,14 +375,16 @@ def circuit_to_ordering(
 
     qubit_order = qubit_order_method.order_for(circuit.all_qubits())
 
-    cut_indices = set()
+    cut_indices = {}
     min_cost = math.inf
     min_steps = []
     for _ in range(max_cuts):
         # Loop over possible cuts.
         min_cut = None
         tested_pairs = set()
+        min_cut_dim = 1
         for cut_op in circuit.all_operations():
+            cut_dim = 1
             cut_index = frozenset(cut_op.qubits)
             if cut_index in tested_pairs or cut_index in cut_indices:
                 continue
@@ -351,20 +395,29 @@ def circuit_to_ordering(
                 index = frozenset(op.qubits)
                 if index != cut_index and index not in cut_indices:
                     g.add_bond(op.qubits, op)
+                elif index == cut_index:
+                    cut_dim *= utils.ComputeSchmidtRank(op)
             cost, steps = get_steps_for_graph(g)
             if cost < min_cost:
                 min_cost = cost
                 min_cut = cut_op.qubits
+                min_cut_dim = cut_dim
                 min_steps = steps
         if min_cut:
-            cut_indices.add(frozenset(min_cut))
+            cut_indices[frozenset(min_cut)] = min_cut_dim
         else:  # Cut failed to reduce contraction cost; stop early.
             break
     order_data = []
-    for cut in cut_indices:
-        order_data.append('cut () %d %d' %
-                          tuple(qubit_names[qubit_order.index(c)] for c in cut))
+    final_fidelity, cut_ratios = match_fidelity(fidelity, cut_indices)
+    for cut, width, dim in cut_ratios:
+        cut_qubits = tuple(cut)
+        cut_ids = tuple(qubit_names[qubit_order.index(c)] for c in cut)
+        order_data.append('# cut bond {} of dim={}'.format(cut_qubits, dim))
+        order_data.append('cut {} {} {}'.format(tuple(range(width)), cut_ids[0],
+                                                cut_ids[1]))
+    order_data.append('# approximate fidelity: {}'.format(final_fidelity))
     order_data += create_ordering_data(min_steps, qubit_names, qubit_order)
+
     return order_data
 
 
@@ -379,6 +432,8 @@ if __name__ == "__main__":
         '<grid_filename>']
     circuit_filename = args['--circuit'] if args['--circuit'] != None else args[
         '<circuit_filename>']
+    max_cuts = int(args['--max_cuts']) if args['--max_cuts'] != None else 2
+    fidelity = float(args['--fidelity']) if args['--fidelity'] != None else 1.0
     output_filename = args['--output-file']
     verbose = args['--verbose']
 
@@ -395,7 +450,8 @@ if __name__ == "__main__":
     if verbose:
         print('Compute ordering.', file=stderr)
 
-    ordering = circuit_to_ordering(circuit, qubit_names=sorted(qubits))
+    ordering = circuit_to_ordering(circuit=circuit, qubit_names=sorted(qubits),
+                                   max_cuts=max_cuts, fidelity=fidelity)
     with (stdout
           if output_filename is None else open(output_filename, 'w')) as f:
         print('\n'.join(ordering), file=f)

--- a/python/ordering/order_circuit_simulation.py
+++ b/python/ordering/order_circuit_simulation.py
@@ -302,8 +302,9 @@ def match_fidelity(target_fidelity: float, cuts: Dict[frozenset, int]):
       (cut qubits, cut width, cut_dimension).
   """
     if (target_fidelity == 1.0):
-        return (1.0, zip(list(cuts.keys()), list(cuts.values()),
-                         list(cuts.values())))
+        return (1.0,
+                zip(list(cuts.keys()), list(cuts.values()),
+                    list(cuts.values())))
 
     value_sets = []
     denominator = 1.0
@@ -321,9 +322,11 @@ def match_fidelity(target_fidelity: float, cuts: Dict[frozenset, int]):
         for width in width_set:
             fidelity *= width
         fidelity /= denominator
-        if fidelity > target_fidelity and fidelity < closest_fidelity:
+        if fidelity >= target_fidelity and fidelity < closest_fidelity:
             closest_set = width_set
             closest_fidelity = fidelity
+            if fidelity == target_fidelity:
+                break
 
     return (closest_fidelity,
             zip(list(cuts.keys()), closest_set, list(cuts.values())))

--- a/tests/python/order_circuit_simulation_test.py
+++ b/tests/python/order_circuit_simulation_test.py
@@ -131,3 +131,8 @@ def test_max_cuts_negative_fails():
     # max_cuts cannot be less than zero.
     with pytest.raises(ValueError):
         order_lib.circuit_to_ordering(circuit=circuit, max_cuts=-1)
+
+
+def test_match_fidelity():
+    """Tests the fidelity-matching method."""
+    # DO NOT SUBMIT without implementing this test!

--- a/tests/python/order_circuit_simulation_test.py
+++ b/tests/python/order_circuit_simulation_test.py
@@ -63,22 +63,25 @@ def test_circuit_to_ordering():
                 r -= 1
 
     circuit = cirq.Circuit(moments)
-    order = order_lib.circuit_to_ordering(circuit)
+    order = order_lib.circuit_to_ordering(circuit=circuit, max_cuts=2)
     # Log the ordering file for debugging purposes.
     print("\n".join(order))
-    assert len(order) == 36
+    assert len(order) == 39
     # The order of these two operations doesn't matter, and cuts may have their
     # indices Iswapped.
+    # cut bond (cirq.GridQubit(3, 1), cirq.GridQubit(3, 2)) of dim 16
     cut1 = set(["cut () 13 14", "cut () 14 13"])
+    # cut bond (cirq.GridQubit(1, 0), cirq.GridQubit(2, 0)) of dim 4
     cut2 = set(["cut () 9 10", "cut () 10 9"])
-    assert cut1.intersection(set(order[0:2]))
-    assert cut2.intersection(set(order[0:2]))
+    # approximate fidelity: 1.0
+    assert cut1.intersection(set([order[1], order[3]]))
+    assert cut2.intersection(set([order[1], order[3]]))
     # These are the lines with commands.
     command_indices = [
-        3, 4, 6, 7, 9, 10, 12, 14, 16, 18, 20, 22, 24, 26, 27, 29
+        6, 7, 9, 10, 12, 13, 15, 17, 19, 21, 23, 25, 27, 29, 30, 32
     ]
-    order2_30 = [order[i] for i in command_indices]
-    assert order2_30 == [
+    order5_33 = [order[i] for i in command_indices]
+    assert order5_33 == [
         # 1: ['ISWAP((3, 2), (3, 3))', 'ISWAP((3, 2), (3, 3))', 'CZ((3, 2), (3, 3))']
         "expand A 14",
         "expand A 15",
@@ -111,10 +114,10 @@ def test_circuit_to_ordering():
     # The order of these two operations doesn't matter.
     # 13: ['ISWAP((1, 0), (2, 0))', 'ISWAP((1, 0), (2, 0))', 'CZ((1, 0), (2, 0))']
     # 14: ['ISWAP((1, 1), (2, 1))', 'ISWAP((1, 1), (2, 1))', 'CZ((1, 1), (2, 1))', 'ISWAP((2, 0), (2, 1))', 'ISWAP((2, 0), (2, 1))']
-    assert (["expand C 9", "merge C D"] == [order[31], order[33]] or
-            ["merge C D", "expand D 9"] == [order[31], order[33]])
+    assert (["expand C 9", "merge C D"] == [order[34], order[36]] or
+            ["merge C D", "expand D 9"] == [order[34], order[36]])
     # 15: ['ISWAP((2, 1), (3, 1))', 'CZ((2, 1), (3, 1))', 'ISWAP((3, 0), (3, 1))', 'CZ((3, 0), (3, 1))']
-    assert order[35] == "expand D 13"
+    assert order[38] == "expand D 13"
 
 
 def test_max_cuts_negative_fails():

--- a/tests/python/order_circuit_simulation_test.py
+++ b/tests/python/order_circuit_simulation_test.py
@@ -138,4 +138,41 @@ def test_max_cuts_negative_fails():
 
 def test_match_fidelity():
     """Tests the fidelity-matching method."""
-    # DO NOT SUBMIT without implementing this test!
+    qubits = [
+        cirq.GridQubit(0, 0),
+        cirq.GridQubit(0, 1),
+        cirq.GridQubit(1, 1),
+        cirq.GridQubit(1, 0)
+    ]
+    cuts = [(frozenset([qubits[0], qubits[1]]), 4),
+            (frozenset([qubits[1], qubits[2]]), 8),
+            (frozenset([qubits[2], qubits[3]]), 16),
+            (frozenset([qubits[3], qubits[0]]), 32)]
+
+    # Check that cut dimension affects resulting fidelity.
+    target_fidelity = 17.0 / 32.0
+    for cut in cuts:
+        dim = cut[1]
+        fidelity, unused_data = order_lib.match_fidelity(
+            target_fidelity, dict([cut]))
+        assert fidelity == float(dim / 2 + 1) / dim
+
+    # Check that different sets of cuts can have different result fidelities,
+    # even if the total cut dimension is the same.
+    target_fidelity = (3.0 / 4.0) * (19.0 / 32.0)
+    fidelity, unused_data = order_lib.match_fidelity(target_fidelity,
+                                                     dict([cuts[0], cuts[3]]))
+    assert fidelity == target_fidelity
+    fidelity, unused_data = order_lib.match_fidelity(target_fidelity,
+                                                     dict([cuts[1], cuts[2]]))
+    # This is the closest possible fidelity with dimensions (8, 16).
+    assert fidelity == (6.0 / 8.0) * (10.0 / 16.0)
+
+    # Check that cut order does not affect fidelity.
+    target_fidelity = (3.0 / 4.0) * (5.0 / 8.0) * (11.0 / 16.0) * (23.0 / 32.0)
+    fidelity, unused_data = order_lib.match_fidelity(target_fidelity,
+                                                     dict(cuts))
+    assert fidelity == target_fidelity
+    fidelity, unused_data = order_lib.match_fidelity(target_fidelity,
+                                                     dict(cuts[::-1]))
+    assert fidelity == target_fidelity


### PR DESCRIPTION
Known issue: determining optimal cut "width" for a given circuit becomes tremendously time-consuming at high total cut dimension.