### PR TITLE
Fix memory cmd argument.

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -7,7 +7,7 @@ CIRQ_IF_DIR = ../python/
 QFLEXLIB = $(CIRQ_IF_DIR)/$(TARGET1)`python3-config --extension-suffix`
 
 OBJS1 = ordering.o grid.o circuit.o evaluate_circuit.o tensor.o contraction_utils.o \
-    read_circuit.o docopt/docopt.o
+    read_circuit.o utils.o docopt/docopt.o
 
 CXXFLAGS += -Idocopt/ -fPIC
 

--- a/src/contraction_utils.cpp
+++ b/src/contraction_utils.cpp
@@ -147,7 +147,8 @@ ContractionData ContractionData::Initialize(
   // Prevent memory allocation from exceeding memory_limit.
   double alloc_size = allocated_space * sizeof(s_type);
   if (alloc_size > global::memory_limit) {
-    throw ERROR_MSG("Required space (", utils::readable_memory_string(alloc_size),
+    throw ERROR_MSG("Required space (",
+                    utils::readable_memory_string(alloc_size),
                     ") exceeds memory limit (",
                     utils::readable_memory_string(global::memory_limit),
                     "). Cancelling simulation.");

--- a/src/contraction_utils.cpp
+++ b/src/contraction_utils.cpp
@@ -11,22 +11,6 @@
 
 namespace qflex {
 
-namespace {
-
-// Convert 'memory' bytes into a more readable string.
-std::string readable_memory_string(double memory) {
-  std::string suffix[] = {" B", " kB", " MB", " GB"};
-  std::size_t scale = 0;
-  double size_prefix = memory;
-  while (size_prefix >= (1 << 10)) {
-    ++scale;
-    size_prefix /= (1 << 10);
-  }
-  return utils::concat(size_prefix, suffix[scale]);
-}
-
-}  // namespace
-
 // ContractionData methods
 
 ContractionData ContractionData::Initialize(
@@ -163,9 +147,9 @@ ContractionData ContractionData::Initialize(
   // Prevent memory allocation from exceeding memory_limit.
   double alloc_size = allocated_space * sizeof(s_type);
   if (alloc_size > global::memory_limit) {
-    throw ERROR_MSG("Required space (", readable_memory_string(alloc_size),
+    throw ERROR_MSG("Required space (", utils::readable_memory_string(alloc_size),
                     ") exceeds memory limit (",
-                    readable_memory_string(global::memory_limit),
+                    utils::readable_memory_string(global::memory_limit),
                     "). Cancelling simulation.");
   }
 
@@ -174,7 +158,7 @@ ContractionData ContractionData::Initialize(
   // significantly from this value.
   if (global::verbose > 0) {
     std::size_t old_precision = std::cerr.precision(6);
-    std::cerr << "Allocating " << readable_memory_string(alloc_size)
+    std::cerr << "Allocating " << utils::readable_memory_string(alloc_size)
               << " for this simulation." << std::endl;
     std::cerr.precision(old_precision);
   }

--- a/src/global.h
+++ b/src/global.h
@@ -5,8 +5,8 @@ namespace qflex::global {
 
 inline int verbose = 0;
 
-// Default limit of one gigabyte.
-inline std::size_t memory_limit = 1L << 30;
+// Max allowed memory
+inline std::size_t memory_limit;
 
 }  // namespace qflex::global
 

--- a/src/global.h
+++ b/src/global.h
@@ -3,10 +3,11 @@
 
 namespace qflex::global {
 
+// Default verbose level
 inline int verbose = 0;
 
-// Max allowed memory
-inline std::size_t memory_limit;
+// Max allowed memory (default: 1GB)
+inline std::size_t memory_limit = 1L << 30;
 
 }  // namespace qflex::global
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,10 @@
-#include "memory.h"
 #include "circuit.h"
 #include "docopt.h"
 #include "evaluate_circuit.h"
 #include "global.h"
 #include "grid.h"
 #include "input.h"
+#include "memory.h"
 #include "ordering.h"
 
 static const char VERSION[] = "qFlex v0.1";
@@ -87,9 +87,9 @@ int main(int argc, char** argv) {
                                     : args["<grid_filename>"].asString();
 
     // set alarms to get memory usage in real time
-    if(qflex::global::verbose > 0) {
+    if (qflex::global::verbose > 0) {
       signal(SIGALRM, qflex::memory::print_peak_memory_usage);
-      ualarm(1e5,1e5);
+      ualarm(1e5, 1e5);
     }
 
     // Load circuit
@@ -110,9 +110,10 @@ int main(int argc, char** argv) {
                       "]");
     }
     // If no error is caught, amplitudes will be initialized.
-    
-    if(qflex::global::verbose > 0)
-      std::cerr << "Peak memory usage: " << qflex::memory::get_peak_memory_usage() << std::endl;
+
+    if (qflex::global::verbose > 0)
+      std::cerr << "Peak memory usage: "
+                << qflex::memory::get_peak_memory_usage() << std::endl;
 
     // Printing output.
     for (std::size_t c = 0; c < amplitudes.size(); ++c) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,8 +13,8 @@ static const char USAGE[] =
 tensor network, CPU-based simulator of large quantum circuits.
 
   Usage:
-    qflex <circuit_filename> <ordering_filename> <grid_filename> [<initial_conf> <final_conf> --verbosity <verbosity_level> --memory <memory_limit>]
-    qflex -c <circuit_filename> -o <ordering_filename> -g <grid_filename> [--initial-conf <initial_conf> --final-conf <final_conf> --verbosity <verbosity_level> --memory <memory_limit>]
+    qflex <circuit_filename> <ordering_filename> <grid_filename> [<initial_conf> <final_conf> <verbosity_level> <memory_limit>]
+    qflex -c <circuit_filename> -o <ordering_filename> -g <grid_filename> [--initial-conf=<initial_conf> --final-conf=<final_conf> --verbosity=<verbosity_level> --memory=<memory_limit>]
     qflex (-h | --help)
     qflex --version
 
@@ -51,8 +51,6 @@ int main(int argc, char** argv) {
       qflex::global::verbose = args["--verbosity"].asLong();
     else if (static_cast<bool>(args["<verbosity_level>"]))
       qflex::global::verbose = args["<verbosity_level>"].asLong();
-    else
-      qflex::global::verbose = 0;
 
     // Update global qflex::global::memory_limit
     if (static_cast<bool>(args["--memory"]))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,9 +56,11 @@ int main(int argc, char** argv) {
 
     // Update global qflex::global::memory_limit
     if (static_cast<bool>(args["--memory"]))
-      qflex::global::memory_limit = qflex::utils::from_readable_memory_string(args["--memory"].asString());
+      qflex::global::memory_limit = qflex::utils::from_readable_memory_string(
+          args["--memory"].asString());
     else if (static_cast<bool>(args["<memory_limit>"]))
-      qflex::global::memory_limit = qflex::utils::from_readable_memory_string(args["<memory_limit>"].asString());
+      qflex::global::memory_limit = qflex::utils::from_readable_memory_string(
+          args["<memory_limit>"].asString());
 
     // Get initial/final configurations
     if (static_cast<bool>(args["--initial-conf"]))
@@ -85,7 +87,10 @@ int main(int argc, char** argv) {
 
     // Print info on maximum memory
     if (qflex::global::verbose > 0)
-      std::cerr << "Maximum allowed memory: " << qflex::utils::readable_memory_string(qflex::global::memory_limit) << std::endl;
+      std::cerr << "Maximum allowed memory: "
+                << qflex::utils::readable_memory_string(
+                       qflex::global::memory_limit)
+                << std::endl;
 
     // set alarms to get memory usage in real time
     if (qflex::global::verbose > 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ tensor network, CPU-based simulator of large quantum circuits.
     -o,--ordering=<ordering_filename>      Ordering filename.
     -g,--grid=<grid_filename>              Grid filename.
     -v,--verbosity=<verbosity_level>       Verbosity level.
-    -m,--memory=<memory_limit>             Memory limit (default 1GB).
+    -m,--memory=<memory_limit>             Memory limit [default: 1GB].
     --initial-conf=<initial_conf>          Initial configuration.
     --final-conf=<final_conf>              Final configuration.
     --version                              Show version.
@@ -56,12 +56,9 @@ int main(int argc, char** argv) {
 
     // Update global qflex::global::memory_limit
     if (static_cast<bool>(args["--memory"]))
-      qflex::global::memory_limit = args["--memory"].asLong();
+      qflex::global::memory_limit = qflex::utils::from_readable_memory_string(args["--memory"].asString());
     else if (static_cast<bool>(args["<memory_limit>"]))
-      qflex::global::memory_limit = args["<memory_limit>"].asLong();
-    else
-      // Default limit of one gigabyte.
-      qflex::global::memory_limit = 1L << 30;
+      qflex::global::memory_limit = qflex::utils::from_readable_memory_string(args["<memory_limit>"].asString());
 
     // Get initial/final configurations
     if (static_cast<bool>(args["--initial-conf"]))
@@ -85,6 +82,10 @@ int main(int argc, char** argv) {
     std::string grid_filename = static_cast<bool>(args["--grid"])
                                     ? args["--grid"].asString()
                                     : args["<grid_filename>"].asString();
+
+    // Print info on maximum memory
+    if (qflex::global::verbose > 0)
+      std::cerr << "Maximum allowed memory: " << qflex::utils::readable_memory_string(qflex::global::memory_limit) << std::endl;
 
     // set alarms to get memory usage in real time
     if (qflex::global::verbose > 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include "memory.h"
 #include "circuit.h"
 #include "docopt.h"
 #include "evaluate_circuit.h"
@@ -85,6 +86,12 @@ int main(int argc, char** argv) {
                                     ? args["--grid"].asString()
                                     : args["<grid_filename>"].asString();
 
+    // set alarms to get memory usage in real time
+    if(qflex::global::verbose > 0) {
+      signal(SIGALRM, qflex::memory::print_peak_memory_usage);
+      ualarm(1e5,1e5);
+    }
+
     // Load circuit
     input.circuit.load(std::ifstream(circuit_filename));
 
@@ -103,6 +110,9 @@ int main(int argc, char** argv) {
                       "]");
     }
     // If no error is caught, amplitudes will be initialized.
+    
+    if(qflex::global::verbose > 0)
+      std::cerr << "Peak memory usage: " << qflex::memory::get_peak_memory_usage() << std::endl;
 
     // Printing output.
     for (std::size_t c = 0; c < amplitudes.size(); ++c) {

--- a/src/memory.h
+++ b/src/memory.h
@@ -21,7 +21,8 @@ inline std::string get_peak_memory_usage() noexcept {
     line = line.substr(line.find_first_of("0123456789"), std::size(line));
 
     // Strip everything after the first space
-    return utils::readable_memory_string(std::stod(line.substr(0, line.find(' '))) * 1024);
+    return utils::readable_memory_string(
+        std::stod(line.substr(0, line.find(' '))) * 1024);
 
   } else
     return std::string("n/a");

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,36 +1,36 @@
 #ifndef MEMORY__H
 #define MEMORY__H
 
-#include <iostream>
-#include <fstream>
-#include <unistd.h>
 #include <signal.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <iostream>
 
 namespace qflex::memory {
 
 inline std::string get_peak_memory_usage() noexcept {
-
-  if(auto in = std::ifstream("/proc/self/status"); in.good()) {
-
+  if (auto in = std::ifstream("/proc/self/status"); in.good()) {
     // Skip to the desired line
     std::string line;
-    for(std::size_t i = 0; i < 17; ++i) std::getline(in, line);
+    for (std::size_t i = 0; i < 17; ++i) std::getline(in, line);
 
     // Strip everything which is not a number at the beginning of line
     return line.substr(line.find_first_of("0123456789"), std::size(line));
 
-  } else return std::string("n/a");
-
+  } else
+    return std::string("n/a");
 }
 
 inline void print_peak_memory_usage(int _ = 0) noexcept {
   static std::string old_vm_size = get_peak_memory_usage();
-  if(const std::string vm_size = get_peak_memory_usage(); old_vm_size != vm_size) {
+  if (const std::string vm_size = get_peak_memory_usage();
+      old_vm_size != vm_size) {
     std::cerr << "Memory usage: " << vm_size << std::endl;
     old_vm_size = vm_size;
   }
 }
 
-}
+}  // namespace qflex::memory
 
 #endif

--- a/src/memory.h
+++ b/src/memory.h
@@ -7,6 +7,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "utils.h"
+
 namespace qflex::memory {
 
 inline std::string get_peak_memory_usage() noexcept {
@@ -16,7 +18,10 @@ inline std::string get_peak_memory_usage() noexcept {
     for (std::size_t i = 0; i < 17; ++i) std::getline(in, line);
 
     // Strip everything which is not a number at the beginning of line
-    return line.substr(line.find_first_of("0123456789"), std::size(line));
+    line = line.substr(line.find_first_of("0123456789"), std::size(line));
+
+    // Strip everything after the first space
+    return utils::readable_memory_string(std::stod(line.substr(0, line.find(' '))) * 1024);
 
   } else
     return std::string("n/a");

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,0 +1,36 @@
+#ifndef MEMORY__H
+#define MEMORY__H
+
+#include <iostream>
+#include <fstream>
+#include <unistd.h>
+#include <signal.h>
+
+namespace qflex::memory {
+
+inline std::string get_peak_memory_usage() noexcept {
+
+  if(auto in = std::ifstream("/proc/self/status"); in.good()) {
+
+    // Skip to the desired line
+    std::string line;
+    for(std::size_t i = 0; i < 17; ++i) std::getline(in, line);
+
+    // Strip everything which is not a number at the beginning of line
+    return line.substr(line.find_first_of("0123456789"), std::size(line));
+
+  } else return std::string("n/a");
+
+}
+
+inline void print_peak_memory_usage(int _ = 0) noexcept {
+  static std::string old_vm_size = get_peak_memory_usage();
+  if(const std::string vm_size = get_peak_memory_usage(); old_vm_size != vm_size) {
+    std::cerr << "Memory usage: " << vm_size << std::endl;
+    old_vm_size = vm_size;
+  }
+}
+
+}
+
+#endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -16,6 +16,6 @@ std::string readable_memory_string(double memory) {
   return concat(memory, suffix[scale]);
 }
 
-}
+}  // namespace qflex::utils
 
 #endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -5,6 +5,38 @@
 
 namespace qflex::utils {
 
+// Convert more readable strings into 'memory' bytes.
+std::size_t from_readable_memory_string(std::string memory) {
+
+  // Remove any special character
+  memory = std::regex_replace(memory, std::regex("[^)(\\s\\ta-zA-Z0-9_.,-]"), "");
+
+  // Convert tabs to spaces
+  memory = std::regex_replace(memory, std::regex("[\\t]"), " ");
+
+  // Remove all spaces
+  memory = std::regex_replace(memory, std::regex(" "), "");
+
+  // Convert all letters to uppercase
+  for(auto &c: memory) c = std::toupper(c);
+
+  std::size_t m = std::stoll(memory.substr(0, memory.find_first_not_of("0123456789")));
+
+  {
+    // Find the first non-number and get the suffix
+    const std::string suffix = memory.substr(std::min(memory.find_first_not_of("0123456789"), std::size(memory)), std::size(memory));
+
+    if     (suffix == "GB") m *= std::pow(1024, 3);
+    else if(suffix == "MB") m *= std::pow(1024, 2);
+    else if(suffix == "KB") m *= std::pow(1024, 1);
+    else if(suffix == "B")  m *= std::pow(1024, 0);
+    else if(suffix == "")   m *= std::pow(1024, 0);
+    else throw ERROR_MSG("Suffix ", suffix, " not recognized.");
+  }
+
+  return m;
+}
+
 // Convert 'memory' bytes into a more readable string.
 std::string readable_memory_string(double memory) {
   std::string suffix[] = {" B", " kB", " MB", " GB"};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -13,7 +13,7 @@ std::string readable_memory_string(double memory) {
     ++scale;
     memory /= (1 << 10);
   }
-  return concat(memory, suffix[scale]);
+  return concat(static_cast<std::size_t>(memory*100)/100., suffix[scale]);
 }
 
 }  // namespace qflex::utils

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -7,9 +7,9 @@ namespace qflex::utils {
 
 // Convert more readable strings into 'memory' bytes.
 std::size_t from_readable_memory_string(std::string memory) {
-
   // Remove any special character
-  memory = std::regex_replace(memory, std::regex("[^)(\\s\\ta-zA-Z0-9_.,-]"), "");
+  memory =
+      std::regex_replace(memory, std::regex("[^)(\\s\\ta-zA-Z0-9_.,-]"), "");
 
   // Convert tabs to spaces
   memory = std::regex_replace(memory, std::regex("[\\t]"), " ");
@@ -18,20 +18,29 @@ std::size_t from_readable_memory_string(std::string memory) {
   memory = std::regex_replace(memory, std::regex(" "), "");
 
   // Convert all letters to uppercase
-  for(auto &c: memory) c = std::toupper(c);
+  for (auto &c : memory) c = std::toupper(c);
 
-  std::size_t m = std::stoll(memory.substr(0, memory.find_first_not_of("0123456789")));
+  std::size_t m =
+      std::stoll(memory.substr(0, memory.find_first_not_of("0123456789")));
 
   {
     // Find the first non-number and get the suffix
-    const std::string suffix = memory.substr(std::min(memory.find_first_not_of("0123456789"), std::size(memory)), std::size(memory));
+    const std::string suffix = memory.substr(
+        std::min(memory.find_first_not_of("0123456789"), std::size(memory)),
+        std::size(memory));
 
-    if     (suffix == "GB") m *= std::pow(1024, 3);
-    else if(suffix == "MB") m *= std::pow(1024, 2);
-    else if(suffix == "KB") m *= std::pow(1024, 1);
-    else if(suffix == "B")  m *= std::pow(1024, 0);
-    else if(suffix == "")   m *= std::pow(1024, 0);
-    else throw ERROR_MSG("Suffix ", suffix, " not recognized.");
+    if (suffix == "GB")
+      m *= std::pow(1024, 3);
+    else if (suffix == "MB")
+      m *= std::pow(1024, 2);
+    else if (suffix == "KB")
+      m *= std::pow(1024, 1);
+    else if (suffix == "B")
+      m *= std::pow(1024, 0);
+    else if (suffix == "")
+      m *= std::pow(1024, 0);
+    else
+      throw ERROR_MSG("Suffix ", suffix, " not recognized.");
   }
 
   return m;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -13,7 +13,7 @@ std::string readable_memory_string(double memory) {
     ++scale;
     memory /= (1 << 10);
   }
-  return concat(static_cast<std::size_t>(memory*100)/100., suffix[scale]);
+  return concat(static_cast<std::size_t>(memory * 100) / 100., suffix[scale]);
 }
 
 }  // namespace qflex::utils

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,21 @@
+#ifndef UTILS__CPP
+#define UTILS__CPP
+
+#include "utils.h"
+
+namespace qflex::utils {
+
+// Convert 'memory' bytes into a more readable string.
+std::string readable_memory_string(double memory) {
+  std::string suffix[] = {" B", " kB", " MB", " GB"};
+  std::size_t scale = 0;
+  while (memory >= (1 << 10)) {
+    ++scale;
+    memory /= (1 << 10);
+  }
+  return concat(memory, suffix[scale]);
+}
+
+}
+
+#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,11 +1,11 @@
 #ifndef UTILS__H
 #define UTILS__H
 
-#include <stdexcept>
-#include <sstream>
-#include <string>
-#include <regex>
 #include <cmath>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
 
 #include "errors.h"
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -21,6 +21,9 @@ std::string concat(const T& x, const Q&... y) {
   return ss.str() + concat(y...);
 }
 
+// Convert 'memory' bytes into a more readable string.
+std::string readable_memory_string(double memory);
+
 }  // namespace qflex::utils
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,9 +1,13 @@
 #ifndef UTILS__H
 #define UTILS__H
 
-#include <sstream>
 #include <stdexcept>
+#include <sstream>
 #include <string>
+#include <regex>
+#include <cmath>
+
+#include "errors.h"
 
 namespace qflex::utils {
 
@@ -20,6 +24,9 @@ std::string concat(const T& x, const Q&... y) {
   ss << x;
   return ss.str() + concat(y...);
 }
+
+// Convert more readable strings into 'memory' bytes.
+std::size_t from_readable_memory_string(std::string memory);
 
 // Convert 'memory' bytes into a more readable string.
 std::string readable_memory_string(double memory);

--- a/tests/src/Makefile.in
+++ b/tests/src/Makefile.in
@@ -5,7 +5,7 @@ SRC_DIR = ../../src
 GTEST_DIR = $(CURDIR)/googletest/googletest
 GMOCK_DIR = $(CURDIR)/googletest/googlemock
 
-OBJS1 = ordering.o grid.o circuit.o evaluate_circuit.o tensor.o contraction_utils.o read_circuit.o
+OBJS1 = ordering.o grid.o circuit.o evaluate_circuit.o tensor.o contraction_utils.o read_circuit.o utils.o
 
 TESTFLAGS = -I$(GTEST_DIR)/include -L$(GTEST_DIR) -I$(GMOCK_DIR)/include -L$(GMOCK_DIR) -I$(SRC_DIR)
 


### PR DESCRIPTION
At the moment, `--memory` requires an integer representing the maximum amount of memory (in bytes) allowed during the simulation. This PR fixes the issues by allowing human-readable strings as `10GB`. 