### PR TITLE
Fix memory allocation.

### DIFF
--- a/src/contraction_utils.cpp
+++ b/src/contraction_utils.cpp
@@ -164,7 +164,15 @@ ContractionData ContractionData::Initialize(
     std::cerr.precision(old_precision);
   }
 
-  // Actually allocate the required space.
+  // Reserve space for all the tensors
+  {
+    std::size_t num_tensors = 0;
+    num_tensors += 1;
+    num_tensors += std::size(unique_sizes);
+    num_tensors += std::size(data.patch_max_size_);
+    num_tensors += std::size(cut_copy_size);
+    data.scratch_.reserve(num_tensors);
+  }
 
   // General-purpose scratch space (primarily used for tensor reordering).
   try {

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -121,6 +121,10 @@ void Tensor::_copy(const Tensor& other) {
 }
 
 void Tensor::_move(Tensor&& other) {
+
+  // Clear this tensor before moving the other
+  _clear();
+
   // Move everything
   _indices = std::move(other._indices);
   _dimensions = std::move(other._dimensions);

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -121,7 +121,6 @@ void Tensor::_copy(const Tensor& other) {
 }
 
 void Tensor::_move(Tensor&& other) {
-
   // Clear this tensor before moving the other
   _clear();
 

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -92,6 +92,12 @@ class Tensor {
   Tensor(const Tensor& other);
 
   /**
+   * Move constructor: Move tensor to a new Tensor.
+   * @param other Tensor to be copied.
+   */
+  Tensor(Tensor&& other);
+
+  /**
    * Destructor: frees all memory associated with a given Tensor object.
    * Invoked by the system.
    */
@@ -105,9 +111,16 @@ class Tensor {
    * if this Tensor has at least as much space allocated as other, then
    * everything will run smoothly, with a non-optimal usage of memory.
    * @param other Tensor to copy into the current Tensor.
-   * @return The current Tensor for assignment chaining.
+   * @return The current Tensor after assignment.
    */
   const Tensor& operator=(const Tensor& other);
+
+  /**
+   * Move-assignment operator for moving one tensor to another.
+   * @param other Tensor to move into the current Tensor.
+   * @return The current Tensor after assignment.
+   */
+  const Tensor& operator=(Tensor&& other);
 
   /**
    * Get indices.
@@ -260,10 +273,10 @@ class Tensor {
   std::vector<std::string> _indices;
   std::vector<std::size_t> _dimensions;
   std::unordered_map<std::string, std::size_t> _index_to_dimension;
-  s_type* _data;
+  s_type* _data{nullptr};
 
   // Allocated data space. This value does not change after initialization.
-  std::size_t _capacity;
+  std::size_t _capacity{0};
 
   // Private helper functions.
   /**
@@ -291,6 +304,12 @@ class Tensor {
    * @param other Tensor to copy into the current Tensor.
    */
   void _copy(const Tensor& other);
+
+  /**
+   * Helper function for the move constructor.
+   * @param other Tensor to move into the current Tensor.
+   */
+  void _move(Tensor&& other);
 
   /**
    * Helper function for reorder(). It is called when smart reordering doesn't

--- a/tests/src/tensor_test.cpp
+++ b/tests/src/tensor_test.cpp
@@ -473,14 +473,18 @@ TEST(TensorExceptionTest, Capacity) {
   // Increase size to 8 units; capacity is still 64 units.
   tensor.set_indices_and_dimensions({"k", "m", "n"}, {2, 2, 2});
 
-  // Attempt to increase size to 256 units.
+  // Moving tensors is always allowed
+  tensor = Tensor({"f", "g"}, {16, 16});
+
+  // Copy tensors of different size is not allowed.
   try {
-    tensor = Tensor({"f", "g"}, {16, 16});
+    const auto new_tensor = Tensor({"f", "g", "h"}, {16, 16, 16});
+    tensor = new_tensor;
     FAIL() << "Expected Tensor() to throw an exception.";
   } catch (std::string msg) {
     EXPECT_THAT(msg, testing::HasSubstr(
-                         "The total allocated space: 64, is insufficient for "
-                         "the requested tensor dimensions: 256."));
+                         "The total allocated space: 256, is insufficient for "
+                         "the requested tensor dimensions: 4096."));
   }
 }
 

--- a/tests/src/tensor_test.cpp
+++ b/tests/src/tensor_test.cpp
@@ -476,7 +476,7 @@ TEST(TensorExceptionTest, Capacity) {
   // Moving tensors is always allowed
   tensor = Tensor({"f", "g"}, {16, 16});
 
-  // Copy tensors of different size is not allowed.
+  // Attempt to increase size to 4096 units.
   try {
     const auto new_tensor = Tensor({"f", "g", "h"}, {16, 16, 16});
     tensor = new_tensor;


### PR DESCRIPTION
A `move` operator has been included in the `Tensor` class to avoid the copy of tensors everytime they're pushed somewhere. Also, in `contraction_utils.cpp`, memory for `scratch.data` is reserved ahead to avoid the reallocation and copy of tensors.