### PR TITLE
GPU integration

### DIFF
--- a/src/contraction_utils.h
+++ b/src/contraction_utils.h
@@ -219,6 +219,10 @@ void ContractGrid(const std::list<ContractionOperation>& ordering,
                   std::vector<std::vector<Tensor>>* tensor_grid,
                   std::vector<std::complex<double>>* amplitudes);
 
+// NEW
+void multiply_with_talsh(Tensor& A, Tensor& B, Tensor& C);
+// NEW UP TO HERE
+
 }  // namespace qflex
 
 #endif  // CONTRACTION_UTILS_

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -960,10 +960,22 @@ void _multiply_vv(const s_type* A_data, const s_type* B_data, s_type* C_data,
   cblas_cdotu_sub(k, A_data, 1, B_data, 1, C_data);
 }
 
-void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy) {
+// NEW ERASES
+//void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy) {
+// NEW ERASES UP TO HERE`
+// NEW
+void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy,
+              bool dry /*= false*/) {
+// NEW UP TO HERE`
+  // NEW
+  if (!dry) {
+  // NEW UP TO HERE
   if (scratch_copy == nullptr) {
     throw ERROR_MSG("Scratch copy must be non-null.");
   }
+  // NEW
+  }
+  // NEW UP TO HERE
 
   if (A.data() == C.data()) {
     throw ERROR_MSG("A and C cannot be the same tensor: ",
@@ -1020,6 +1032,9 @@ void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy) {
 
   if (global::verbose > 1) t0 = std::chrono::high_resolution_clock::now();
 
+  // NEW
+  if (!dry) {
+  // NEW UP TO HERE
   // Reorder.
   std::vector<std::string> A_new_ordering =
       _vector_union(left_indices, common_indices);
@@ -1096,6 +1111,9 @@ void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy) {
     std::cerr << "Time multiplying A*B: " << time_span.count() << "s\n";
     t0 = std::chrono::high_resolution_clock::now();
   }
+  // NEW
+  }
+  // NEW UP TO HERE
 
   // Set indices and dimensions of C.
   std::vector<std::string> C_indices =

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -410,7 +410,13 @@ void _multiply_vv(const s_type* A_data, const s_type* B_data, s_type* C_data,
  * reordering. It has to allocate at least as much max(A.size(), B.size())
  * memory.
  */
-void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy);
+// NEW ERASES
+//void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy);
+// NEW ERASES UP TO HERE
+// NEW
+void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy,
+              bool dry = false);
+// NEW UP TO HERE
 
 /**
  * Returns the size of the tensor product of A and B.


### PR DESCRIPTION
Connecting properly to TALSH interface so that GPU contractions are supported. Plan:
1) Get single contractions on GPU.
2) Pipeline GPU contractions.
3) Choose contraction orderings so that pipelines are as long as possible. This should be doable if contractions from two different patch expansions are alternated.
4) Choose what contractions go to CPU, single GPU, or multi-GPU. The single GPU ones are pipelined.