### PR TITLE
Improve tensor class (depends on: #268)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -35,6 +35,9 @@ ifeq ($(PYBIND11), true)
   TARGETS += pybind
 endif
 
+OBJS = ordering.o grid.o circuit.o evaluate_circuit.o tensor.o contraction_utils.o \
+    stopwatch.o read_circuit.o utils.o 
+
 MODULES = docopt
 TESTS_MODULES = googletest
 
@@ -44,6 +47,7 @@ export CPPFLAGS
 export LDFLAGS
 export LIBS
 export FLAGS
+export OBJS
 
 .PHONY: all
 all: $(TARGETS)

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -6,8 +6,7 @@ CIRQ_IF_DIR = ../python/
 # The name of the shared library that results after compiling QFlex for Pybind11
 QFLEXLIB = $(CIRQ_IF_DIR)/$(TARGET1)`python3-config --extension-suffix`
 
-OBJS1 = ordering.o grid.o circuit.o evaluate_circuit.o tensor.o contraction_utils.o \
-    read_circuit.o utils.o docopt/docopt.o
+OBJS1 = $(OBJS) docopt/docopt.o
 
 CXXFLAGS += -Idocopt/ -fPIC
 

--- a/src/contraction_utils.cpp
+++ b/src/contraction_utils.cpp
@@ -159,8 +159,10 @@ ContractionData ContractionData::Initialize(
   // significantly from this value.
   if (global::verbose > 0) {
     std::size_t old_precision = std::cerr.precision(6);
-    std::cerr << "Allocating " << utils::readable_memory_string(alloc_size)
-              << " for this simulation." << std::endl;
+    std::cerr << WARN_MSG("Allocating ",
+                          utils::readable_memory_string(alloc_size),
+                          " for this simulation.")
+              << std::endl;
     std::cerr.precision(old_precision);
   }
 

--- a/src/errors.h
+++ b/src/errors.h
@@ -8,4 +8,7 @@
   qflex::utils::concat("ERROR (" __FILE__ ": ", __FUNCTION__, ":", __LINE__, \
                        ") --> ", __VA_ARGS__)
 
+#define WARN_MSG(...) \
+  qflex::utils::concat("[", qflex::utils::get_date_time(), "] ", __VA_ARGS__)
+
 #endif

--- a/src/evaluate_circuit.cpp
+++ b/src/evaluate_circuit.cpp
@@ -236,8 +236,7 @@ std::vector<std::pair<std::string, std::complex<double>>> EvaluateCircuit(
     const auto time_span =
         std::chrono::duration_cast<std::chrono::duration<double>>(t1 -
                                                                   t_output_0);
-    std::cerr << WARN_MSG("Total time: ", time_span.count(), "s")
-              << std::endl;
+    std::cerr << WARN_MSG("Total time: ", time_span.count(), "s") << std::endl;
   }
 
   return result;

--- a/src/global.h
+++ b/src/global.h
@@ -1,6 +1,8 @@
 #ifndef GLOBAL__H
 #define GLOBAL__H
 
+#include <cstddef>
+
 namespace qflex::global {
 
 // Default verbose level

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,13 +99,13 @@ int main(int argc, char** argv) {
     if (qflex::global::verbose > 0)
       for (const char* var : {"OMP_NUM_THREADS", "MKL_NUM_THREADS"})
         if (const char* value = getenv(var); value != nullptr)
-          std::cerr << var << " = " << value << std::endl;
+          std::cerr << WARN_MSG(var, " = ", value) << std::endl;
 
     // Print info on maximum memory
     if (qflex::global::verbose > 0)
-      std::cerr << "Maximum allowed memory: "
-                << qflex::utils::readable_memory_string(
-                       qflex::global::memory_limit)
+      std::cerr << WARN_MSG("Maximum allowed memory: ",
+                            qflex::utils::readable_memory_string(
+                                qflex::global::memory_limit))
                 << std::endl;
 
     // set alarms to get memory usage in real time

--- a/src/memory.h
+++ b/src/memory.h
@@ -88,12 +88,8 @@ inline std::array<std::string, 2> get_memory_usage() noexcept {
 inline void print_memory_usage(int unused_signal_number = 0) noexcept {
   const auto [vm_used, vm_peak] = get_memory_usage();
 
-  std::time_t t = std::time(nullptr);
-  if (char mbstr[100];
-      std::strftime(mbstr, sizeof(mbstr), "%c", std::localtime(&t)))
-    std::cerr << "[" << mbstr << "] "
-              << "Memory usage: " << vm_used << " (Peak: " << vm_peak << ")"
-              << std::endl;
+  std::cerr << WARN_MSG("Memory usage: ", vm_used, " (Peak: ", vm_peak, ")")
+            << std::endl;
 
   // Reset alarm
   if (global::track_memory_seconds > 0) alarm(global::track_memory_seconds);

--- a/src/stopwatch.cpp
+++ b/src/stopwatch.cpp
@@ -1,0 +1,27 @@
+#include "stopwatch.h"
+
+#include "errors.h"
+
+namespace qflex::utils {
+
+bool Stopwatch::is_running() const { return _running; }
+
+bool Stopwatch::has_started() const { return _started; }
+
+void Stopwatch::start() {
+  if (_started) throw ERROR_MSG("Stopwatch already started.");
+  if (_running) throw ERROR_MSG("Stopwatch already running.");
+  _start = _latest = _split = clock::now();
+  _started = _running = true;
+}
+
+void Stopwatch::stop() {
+  if (!_started) throw ERROR_MSG("Stopwatch never started.");
+  if (!_running) throw ERROR_MSG("Stopwatch is not running.");
+  _latest = clock::now();
+  _running = false;
+}
+
+void Stopwatch::reset() { _started = _running = false; }
+
+}  // namespace qflex::utils

--- a/src/stopwatch.h
+++ b/src/stopwatch.h
@@ -1,0 +1,99 @@
+#ifndef STOPWATCH__H
+#define STOPWATCH__H
+
+#include <chrono>
+
+#include "errors.h"
+
+namespace qflex::utils {
+
+using nanoseconds = std::chrono::nanoseconds;
+using microseconds = std::chrono::microseconds;
+using milliseconds = std::chrono::milliseconds;
+using seconds = std::chrono::seconds;
+using minutes = std::chrono::minutes;
+using hours = std::chrono::hours;
+
+struct Stopwatch {
+  using clock = std::chrono::steady_clock;
+
+  /**
+   * Initialize Stopwatch
+   */
+  Stopwatch() {}
+
+  Stopwatch(const Stopwatch &) = delete;
+  Stopwatch(Stopwatch &&) = delete;
+
+  Stopwatch &operator=(const Stopwatch &) = delete;
+  Stopwatch &operator=(Stopwatch &&) = delete;
+
+  /**
+   * Check if stopwatch is running
+   * @return true if stopwatch is running, false otherwise.
+   */
+  bool is_running() const;
+
+  /**
+   * Check if stopwatch has started
+   * @return true id stopwatch has already started, false otherwise.
+   */
+  bool has_started() const;
+
+  /**
+   * Start Stopwatch
+   */
+  void start();
+
+  /**
+   * Stop Stopwatch
+   */
+  void stop();
+
+  /**
+   * Reset Stopwatch
+   */
+  void reset();
+
+  /**
+   * Compute the difference in time between clock::now() and the last _split.
+   * @return a difference in time in number (std::size_t) of units
+   */
+  template <typename unit>
+  std::size_t split() {
+    if (!has_started()) throw ERROR_MSG("Stopwatch never started.");
+
+    if (!is_running()) throw ERROR_MSG("Stopwatch is not running.");
+
+    auto _now = clock::now();
+    auto _delta_time = std::chrono::duration_cast<unit>(_now - _split);
+    _split = _now;
+    return _delta_time.count();
+  }
+
+  /**
+   * Compute the difference in time between _start and _latest. If _latest <=
+   * _start, then it compute the difference in time between _start and
+   * clock::now()
+   * @return a difference in time in number (std::size_t) of units
+   */
+  template <typename unit>
+  std::size_t time_passed() const {
+    if (!has_started()) throw ERROR_MSG("Stopwatch never started.");
+
+    if (is_running()) throw ERROR_MSG("Stopwatch is still running.");
+
+    return std::chrono::duration_cast<unit>(
+               (_latest > _start ? _latest : clock::now()) - _start)
+        .count();
+  }
+
+ private:
+  bool _started{false};
+  bool _running{false};
+  std::chrono::time_point<clock> _start, _latest, _split;
+};
+
+}  // namespace qflex::utils
+
+#endif

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -1035,7 +1035,8 @@ void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy) {
     t1 = std::chrono::high_resolution_clock::now();
     time_span =
         std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0);
-    std::cerr << "Time preparing variables: " << time_span.count() << "s\n";
+    std::cerr << WARN_MSG("Time preparing variables: ", time_span.count(), "s")
+              << std::endl;
   }
 
   // Check.
@@ -1060,8 +1061,10 @@ void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy) {
     t1 = std::chrono::high_resolution_clock::now();
     time_span =
         std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0);
-    std::cerr << "R " << time_span.count() << " s\n";
-    std::cerr << "Time reordering A: " << time_span.count() << "s\n";
+    std::cerr << WARN_MSG("R ", time_span.count(), "s") << std::endl;
+    ;
+    std::cerr << WARN_MSG("Time reordering A: ", time_span.count(), "s")
+              << std::endl;
     t0 = std::chrono::high_resolution_clock::now();
   }
 
@@ -1077,8 +1080,9 @@ void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy) {
     t1 = std::chrono::high_resolution_clock::now();
     time_span =
         std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0);
-    std::cerr << "R " << time_span.count() << " s\n";
-    std::cerr << "Time reordering B: " << time_span.count() << "s\n";
+    std::cerr << WARN_MSG("R ", time_span.count(), "s") << std::endl;
+    std::cerr << WARN_MSG("Time reordering B: ", time_span.count(), "s")
+              << std::endl;
     t0 = std::chrono::high_resolution_clock::now();
   }
 
@@ -1119,8 +1123,9 @@ void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy) {
     t1 = std::chrono::high_resolution_clock::now();
     time_span =
         std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0);
-    std::cerr << "M " << time_span.count() << " s\n";
-    std::cerr << "Time multiplying A*B: " << time_span.count() << "s\n";
+    std::cerr << WARN_MSG("M ", time_span.count(), "s") << std::endl;
+    std::cerr << WARN_MSG("Time multiplying A*B: ", time_span.count(), "s")
+              << std::endl;
     t0 = std::chrono::high_resolution_clock::now();
   }
 
@@ -1146,7 +1151,9 @@ void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy) {
     t1 = std::chrono::high_resolution_clock::now();
     time_span =
         std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0);
-    std::cerr << "Time updating C's variables: " << time_span.count() << "s\n";
+    std::cerr << WARN_MSG("Time updating C's variables: ", time_span.count(),
+                          "s")
+              << std::endl;
   }
 }
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "tensor.h"
+
 #include "errors.h"
 #include "global.h"
 
@@ -28,10 +29,10 @@
 #endif
 
 #include <algorithm>
-#include <iterator>
-#include <iostream>
-#include <string>
 #include <cmath>
+#include <iostream>
+#include <iterator>
+#include <string>
 
 // Time
 #include <chrono>

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -15,9 +15,6 @@
 
 #include "tensor.h"
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
 
 #include <algorithm>
 #include <cmath>
@@ -95,31 +92,6 @@ void Tensor::_clear() {
   }
 }
 
-void Tensor::_copy(const Tensor& other) {
-  if (_indices.empty()) {
-    _capacity = other.size();
-    _data = new s_type[_capacity];
-  } else {
-    // The line "set_dimensions(other.get_dimensions());" takes care of the
-    // total size of the dimensions.
-    try {
-      set_dimensions(other.get_dimensions());
-    } catch (const std::string& err_msg) {
-      throw ERROR_MSG("Failed to call set_dimensions(). Error:\n\t[", err_msg,
-                      "]");
-    }
-  }
-  try {
-    _init(other.get_indices(), other.get_dimensions());
-  } catch (const std::string& err_msg) {
-    throw ERROR_MSG("Failed to call _init(). Error:\n\t[", err_msg, "]");
-  }
-
-#pragma omp parallel for schedule(static, MAX_RIGHT_DIM)
-  for (std::size_t p = 0; p < other.size(); ++p)
-    *(_data + p) = *(other.data() + p);
-}
-
 void Tensor::_move(Tensor&& other) {
   // Clear this tensor before moving the other
   _clear();
@@ -160,8 +132,9 @@ Tensor::Tensor(std::vector<std::string> indices,
                     ", has to match the size of the Tensor: ", this_size);
   }
   _capacity = this_size;
+
   // Fill in the _data.
-  for (std::size_t i = 0; i < this_size; ++i) *(_data + i) = data[i];
+  std::copy(std::begin(data), std::end(data), _data);
 }
 
 Tensor::Tensor(std::vector<std::string> indices,
@@ -178,7 +151,17 @@ Tensor::Tensor(std::vector<std::string> indices,
   _data = data;
 }
 
-Tensor::Tensor(const Tensor& other) { _copy(other); }
+Tensor::Tensor(const Tensor& other)
+    : _indices{other._indices},
+      _dimensions{other._dimensions},
+      _index_to_dimension{other._index_to_dimension},
+      _capacity{other._capacity} {
+  // Allocate space
+  _data = new s_type[_capacity];
+
+  // Copy data
+  std::copy(other._data, other._data + other._capacity, _data);
+}
 
 Tensor::Tensor(Tensor&& other) { _move(std::move(other)); }
 
@@ -186,8 +169,33 @@ Tensor::~Tensor() { _clear(); }
 
 const Tensor& Tensor::operator=(const Tensor& other) {
   if (other._data != nullptr && this != &other) {
-    _copy(other);
+    // Check indices
+    if (_indices.empty()) {
+      _capacity = other.size();
+      _data = new s_type[_capacity];
+
+    } else {
+      // The line "set_dimensions(other.get_dimensions());" takes care of the
+      // total size of the dimensions.
+      try {
+        set_dimensions(other.get_dimensions());
+      } catch (const std::string& err_msg) {
+        throw ERROR_MSG("Failed to call set_dimensions(). Error:\n\t[", err_msg,
+                        "]");
+      }
+    }
+
+    // Initialize copy
+    try {
+      _init(other.get_indices(), other.get_dimensions());
+    } catch (const std::string& err_msg) {
+      throw ERROR_MSG("Failed to call _init(). Error:\n\t[", err_msg, "]");
+    }
+
+    // Copy memory
+    std::copy(other.data(), other.data() + std::size(other), _data);
   }
+
   return *this;
 }
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -187,7 +187,6 @@ Tensor::Tensor(const std::vector<std::string>& indices,
 #endif
 }
 
-
 Tensor::Tensor(const Tensor& other) { _copy(other); }
 
 Tensor::Tensor(Tensor&& other) { _move(std::move(other)); }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -15,7 +15,6 @@
 
 #include "tensor.h"
 
-
 #include <algorithm>
 #include <cmath>
 #include <iterator>

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -159,7 +159,7 @@ Tensor::Tensor(const Tensor& other)
   _data = new s_type[_capacity];
 
   // Copy data
-  std::copy(other._data, other._data + other._capacity, _data);
+  std::copy(other._data, other._data + std::size(other), _data);
 }
 
 Tensor::Tensor(Tensor&& other) { _move(std::move(other)); }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -14,10 +14,24 @@
  */
 
 #include "tensor.h"
+#include "errors.h"
+#include "global.h"
+
+#ifdef MKL_TENSOR
+#include <mkl.h>
+#else
+#include <cblas.h>
+#endif
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 #include <algorithm>
-#include <cmath>
 #include <iterator>
+#include <iostream>
+#include <string>
+#include <cmath>
 
 // Time
 #include <chrono>

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -108,7 +108,7 @@ void Tensor::_copy(const Tensor& other) {
   if (_indices.empty()) {
     if (_data != nullptr) throw ERROR_MSG("Potential memory leak");
 
-    _capacity = other.size();
+    _capacity = other._capacity;
     _data = new s_type[_capacity];
 
   } else {

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -64,7 +64,6 @@ class Tensor {
          const std::vector<std::size_t>& dimensions,
          const std::vector<s_type>& data);
 
-
   /**
    * Copy constructor: creates a new Tensor that is a copy of another.
    * @param other Tensor to be copied.

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -17,24 +17,9 @@
 #ifndef TENSOR_H
 #define TENSOR_H
 
-#ifdef MKL_TENSOR
-#include <mkl.h>
-#else
-#include <cblas.h>
-#endif
-
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
-#include <complex>
-#include <iostream>
-#include <string>
 #include <unordered_map>
+#include <complex>
 #include <vector>
-
-#include "errors.h"
-#include "global.h"
 
 namespace qflex {
 

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -45,7 +45,8 @@ class Tensor {
    * @param dimensions std::vector<std::size_t> with the ordered dimensions of
    * the indices.
    */
-  Tensor(std::vector<std::string> indices, std::vector<std::size_t> dimensions);
+  Tensor(const std::vector<std::string>& indices,
+         const std::vector<std::size_t>& dimensions);
 
   /**
    * Creates a Tensor. New space is allocated and filled with a copy of
@@ -59,20 +60,10 @@ class Tensor {
    * match in length the dimension of the Tensor, as given by the
    * dimensions.
    */
-  Tensor(std::vector<std::string> indices, std::vector<std::size_t> dimensions,
+  Tensor(const std::vector<std::string>& indices,
+         const std::vector<std::size_t>& dimensions,
          const std::vector<s_type>& data);
 
-  /**
-   * Creates a Tensor. A pointer to the data is passed.
-   * @param indices std::vector<std::string> with the names of the indices in
-   * order.
-   * @param dimensions std::vector<std::size_t> with the ordered dimensions of
-   * the indices.
-   * @param data pointer to the data of the tensor. It is responsibility of
-   * the user to provide enough allocated memory to store the Tensor.
-   */
-  Tensor(std::vector<std::string> indices, std::vector<std::size_t> dimensions,
-         s_type* data);
 
   /**
    * Copy constructor: creates a new Tensor that is a copy of another.
@@ -284,6 +275,15 @@ class Tensor {
    * Helper function for the destructor. Clear memory.
    */
   void _clear();
+
+  /**
+   * Helper function for the copy constructor and the assignment operator.
+   * It is responsibility of the user to copy onto a Tensor with the same
+   * total dimension as other. If there is space allocated, no new space will
+   * be allocated. Changing the size of a Tensor is not allowed.
+   * @param other Tensor to copy into the current Tensor.
+   */
+  void _copy(const Tensor& other);
 
   /**
    * Helper function for the move constructor.

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -23,6 +23,10 @@
 #include <cblas.h>
 #endif
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 #include <complex>
 #include <iostream>
 #include <string>
@@ -295,15 +299,6 @@ class Tensor {
    * Helper function for the destructor. Clear memory.
    */
   void _clear();
-
-  /**
-   * Helper function for the copy constructor and the assignment operator.
-   * It is responsibility of the user to copy onto a Tensor with the same
-   * total dimension as other. If there is space allocated, no new space will
-   * be allocated. Changing the size of a Tensor is not allowed.
-   * @param other Tensor to copy into the current Tensor.
-   */
-  void _copy(const Tensor& other);
 
   /**
    * Helper function for the move constructor.

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -17,8 +17,8 @@
 #ifndef TENSOR_H
 #define TENSOR_H
 
-#include <unordered_map>
 #include <complex>
+#include <unordered_map>
 #include <vector>
 
 namespace qflex {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -5,6 +5,16 @@
 
 namespace qflex::utils {
 
+// Return date and time in the representation: Thu Aug 23 14:55:02 2001
+std::string get_date_time() {
+  std::time_t t = std::time(nullptr);
+  if (char mbstr[100];
+      std::strftime(mbstr, sizeof(mbstr), "%c", std::localtime(&t)))
+    return mbstr;
+  else
+    return "n/a";
+}
+
 // Convert more readable strings into 'memory' bytes.
 std::size_t from_readable_memory_string(std::string memory) {
   // Remove any special character

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -12,7 +12,7 @@ std::string get_date_time() {
       std::strftime(mbstr, sizeof(mbstr), "%c", std::localtime(&t)))
     return mbstr;
   else
-    return "n/a";
+    return "[time-readout error]";
 }
 
 // Convert more readable strings into 'memory' bytes.

--- a/src/utils.h
+++ b/src/utils.h
@@ -25,6 +25,9 @@ std::string concat(const T& x, const Q&... y) {
   return ss.str() + concat(y...);
 }
 
+// Return date and time in the representation: Thu Aug 23 14:55:02 2001
+std::string get_date_time();
+
 // Convert more readable strings into 'memory' bytes.
 std::size_t from_readable_memory_string(std::string memory);
 

--- a/tests/src/Makefile.in
+++ b/tests/src/Makefile.in
@@ -5,7 +5,7 @@ SRC_DIR = ../../src
 GTEST_DIR = $(CURDIR)/googletest/googletest
 GMOCK_DIR = $(CURDIR)/googletest/googlemock
 
-OBJS1 = ordering.o grid.o circuit.o evaluate_circuit.o tensor.o contraction_utils.o read_circuit.o utils.o
+OBJS1 = $(OBJS)
 
 TESTFLAGS = -I$(GTEST_DIR)/include -L$(GTEST_DIR) -I$(GMOCK_DIR)/include -L$(GMOCK_DIR) -I$(SRC_DIR)
 

--- a/tests/src/tensor_test.cpp
+++ b/tests/src/tensor_test.cpp
@@ -511,14 +511,6 @@ TEST(TensorExceptionTest, InvalidInput) {
             "The vector data size: 8, has to match the size of the Tensor: 4"));
   }
 
-  // Data passed into Tensor cannot be null pointer.
-  try {
-    Tensor({"a", "b"}, {2, 2}, nullptr);
-    FAIL() << "Expected Tensor() to throw an exception.";
-  } catch (std::string msg) {
-    EXPECT_THAT(msg, testing::HasSubstr("Data must be non-null."));
-  }
-
   Tensor tensor_abc({"a", "b", "c"}, {2, 2, 2});
   Tensor tensor_ac({"a", "c"}, {2, 2});
 


### PR DESCRIPTION
Copy/Move constructors and copy/move assignment operators are now 
consistent with their function. Now, the following code:
```
std::vector<std::vector<Tensor>> tensors(...);
[...]
auto copy_tensors = tensors;
```
works without segmentation fault.