### PR TITLE
Allow lone qubits, but log a warning.

### DIFF
--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -867,6 +867,15 @@ void Tensor::reorder(std::vector<std::string> new_ordering,
   if (scratch_copy == nullptr) {
     throw ERROR_MSG("Scratch copy must be non-null.");
   }
+  if (new_ordering.empty() && _indices.empty()) {
+    // Scalars do not require reordering, but may indicate user input error.
+    std::cerr << WARN_MSG(
+                     "Warning: encountered rank-zero tensor during reorder "
+                     "step. This suggests that a qubit is fully disconnected ",
+                     "from the rest of the device.")
+              << std::endl;
+    return;
+  }
 
   // Checks.
   bool new_ordering_in_indices = _vector_s_in_vector_s(new_ordering, _indices);

--- a/tests/src/tensor_test.cpp
+++ b/tests/src/tensor_test.cpp
@@ -413,6 +413,30 @@ TEST(TensorTest, WorstCaseIndexReordering) {
   }
 }
 
+// Tests that "reordering" a scalar does not crash.
+TEST(TensorTest, ReorderScalar) {
+  std::vector<std::string> indices = {};
+  std::vector<size_t> dimensions = {};
+  std::vector<std::complex<float>> data;
+  data.push_back(std::complex<float>(0, 0));
+
+  Tensor tensor(indices, dimensions, data);
+  std::vector<std::string> expected_indices = {};
+  std::array<std::complex<float>, 1> scratch;
+  try {
+    tensor.reorder(expected_indices, scratch.data());
+  } catch (std::string msg) {
+    FAIL()
+        << "Expected tensor.reorder() to succeed but failed with error msg:  "
+        << msg << std::endl;
+  }
+  ASSERT_EQ(tensor.get_indices(), expected_indices);
+  ASSERT_EQ(tensor.get_dimensions(), dimensions);
+
+  // "Reordering" a scalar should not affect it.
+  ASSERT_EQ(data[0], tensor.data()[0]);
+}
+
 // Multiplies two tensors and verify shape, indices, and data of the result.
 TEST(TensorTest, Multiply) {
   std::vector<std::string> indices_a = {"a", "b", "c"};


### PR DESCRIPTION
Fixes #273.

With this change, qubits that have no interactions with other qubits can be included in a circuit and will affect the final amplitude correctly. A warning message will be logged, since this often suggests an error in input file formatting (simulating a single disconnected qubit isn't particularly useful).