### PR TITLE
Fix support for zero-cut orderings.

### DIFF
--- a/qflexcirq/ordering/order_circuit_simulation.py
+++ b/qflexcirq/ordering/order_circuit_simulation.py
@@ -301,7 +301,7 @@ def match_fidelity(target_fidelity: float, cuts: Dict[frozenset, int]):
     The final fidelity approximation and a list of tuples
       (cut qubits, cut width, cut_dimension).
   """
-    if (target_fidelity == 1.0):
+    if (target_fidelity == 1.0 or not cuts):
         return (1.0,
                 zip(list(cuts.keys()), list(cuts.values()),
                     list(cuts.values())))
@@ -384,9 +384,13 @@ def circuit_to_ordering(
     qubit_order = qubit_order_method.order_for(circuit.all_qubits())
 
     cut_indices = {}
-    min_cost = math.inf
-    min_steps = []
-    for _ in range(max_cuts):
+    # Make initial pass prior to cuts.
+    g = Graph(circuit.all_qubits())
+    for op in circuit.all_operations():
+        g.add_bond(op.qubits, op)
+    min_cost, min_steps = get_steps_for_graph(g)
+
+    for cut_num in range(max_cuts):
         # Loop over possible cuts.
         min_cut = None
         tested_pairs = set()

--- a/tests/python/order_circuit_simulation_test.py
+++ b/tests/python/order_circuit_simulation_test.py
@@ -136,6 +136,22 @@ def test_max_cuts_negative_fails():
         order_lib.circuit_to_ordering(circuit=circuit, max_cuts=-1)
 
 
+def test_max_cuts_zero_succeeds():
+    """Tests the circuit-to-ordering conversion."""
+    qubits = [cirq.GridQubit(0, 0), cirq.GridQubit(0, 1)]
+    size = 4
+    for x in range(size):
+        qubits.append([cirq.GridQubit(x, y) for y in range(size)])
+
+    moments = (cirq.Moment([cirq.CZ(qubits[0], qubits[1])]),
+               cirq.Moment([cirq.CZ(qubits[0], qubits[1])]))
+    circuit = cirq.Circuit(moments)
+
+    # max_cuts of zero will generate an ordering.
+    order = order_lib.circuit_to_ordering(circuit=circuit, max_cuts=0)
+    assert len(order) > 1
+
+
 def test_match_fidelity():
     """Tests the fidelity-matching method."""
     qubits = [


### PR DESCRIPTION
Fixes an issue spotted in #284.

Previously, having zero cuts would cause this tool to spit out a blank contraction ordering. This PR adds an initial pass before applying cuts to ensure that zero-cut requests generate an ordering.

One side effect of this is that it is now possible for the auto-ordering tool to stop at zero cuts if adding the first cut fails to improve total cost (although such an occurrence is rare).