### PR TITLE
Update Cirq to v0.8.

### DIFF
--- a/docs/cirq_interface.md
+++ b/docs/cirq_interface.md
@@ -3,10 +3,10 @@
 HOWTO use qFlex from Google [Cirq](https://github.com/quantumlib/cirq).
 * Note: For the moment, the Cirq-qFlex integration is experimental code.
 
-The currently supported version of Cirq is 0.5.0, and newer stable
+The currently supported version of Cirq is 0.8.0, and newer stable
 versions will be supported, once they are available. Therefore, the
-prerequisites are:
-- Cirq 0.6.0 or later
+prerequisites for running qFlex via Cirq are:
+- Cirq 0.8.0 or later
 - qFlex C++ code (the code from this repo)
 
 This file is an example of how to use the qFlex Python interface with Cirq.

--- a/qflexcirq/interface/qflex_circuit.py
+++ b/qflexcirq/interface/qflex_circuit.py
@@ -33,14 +33,14 @@ class QFlexCircuit(cirq.Circuit):
             raise ValueError("{!r} is not of a QFlexOrder!")
 
         if allow_decomposition:
-            super().__init__([], device)
+            super(QFlexCircuit, self).__init__([], device=device)
             for moment in cirq_circuit:
                 for op in moment:
                     # This should call decompose on the gates
                     self.append(op)
         else:
             # This super constructor does not call decompose?
-            super().__init__(cirq_circuit, device)
+            super(QFlexCircuit, self).__init__(cirq_circuit, device=device)
 
         # Behind the scene, this class creates a temporary file for each object
         self.temp_file_if = tmpi.DataStorageInterface()

--- a/qflexcirq/utils.py
+++ b/qflexcirq/utils.py
@@ -184,7 +184,7 @@ def GetCircuitOfMoments(file_name, qubits):
         if len(current_moment) > 0:
             moments.append(cirq.Moment(current_moment))
 
-        return cirq.Circuit(moments=moments)
+        return cirq.Circuit(moments)
 
 
 def GetNumberOfQubits(cirq_circuit):

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
-cirq>=0.6.0
+cirq==0.8.0
 pytest
 docopt
 pybind11

--- a/tests/python/qflex_order_test.py
+++ b/tests/python/qflex_order_test.py
@@ -49,7 +49,7 @@ def test_cirquit_without_qubits():
     """
     with pytest.raises(ValueError):
         assert QFlexOrder(qflex_order_strings=None,
-                          cirq_circuit=cirq.Circuit.from_ops([]))
+                          cirq_circuit=cirq.Circuit([]))
 
 
 def test_automatic_ordering():


### PR DESCRIPTION
Update requirements and docs to point at Cirq 0.8.0 (the latest release). Also updated a couple of deprecated function calls.