### PR TITLE
Fix optimization flag on Power arch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_PROG_CXX
 CXXFLAGS="-O3  -std=c++17  -Wall -Wpedantic -Wno-unused-command-line-argument "$CXXFLAGS
 if test $(uname -m) == "x86_64"; then
   CXXFLAGS="-march=native "$CXXFLAGS
-elif test $(uname -m) == "ppc64le"; then
+elif test $(uname -m) == "ppc64le" || test $(uname -m) == "ppc64"; then
   CXXFLAGS="-mcpu=native "$CXXFLAGS
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -11,10 +11,10 @@ AC_PROG_CXX
 
 # Default CXXFLAGS.
 CXXFLAGS="-O3  -std=c++17  -Wall -Wpedantic -Wno-unused-command-line-argument "$CXXFLAGS
-if test $(uname -m) == "x86_64"; then
-  CXXFLAGS="-march=native "$CXXFLAGS
-elif test $(uname -m) == "ppc64le" || test $(uname -m) == "ppc64"; then
+if test $(uname -m) == "ppc64le" || test $(uname -m) == "ppc64"; then
   CXXFLAGS="-mcpu=native "$CXXFLAGS
+else
+  CXXFLAGS="-march=native "$CXXFLAGS
 fi
 
 # Default LIBS

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,12 @@ AC_LANG(C++)
 AC_PROG_CXX
 
 # Default CXXFLAGS.
-CXXFLAGS="-O3  -std=c++17  -march=native -Wall -Wpedantic -Wno-unused-command-line-argument "$CXXFLAGS
+CXXFLAGS="-O3  -std=c++17  -Wall -Wpedantic -Wno-unused-command-line-argument "$CXXFLAGS
+if test $(uname -m) == "x86_64"; then
+  CXXFLAGS="-march=native "$CXXFLAGS
+elif test $(uname -m) == "ppc64le"; then
+  CXXFLAGS="-mcpu=native "$CXXFLAGS
+fi
 
 # Default LIBS
 LIBS="-lpthread "$LIBS


### PR DESCRIPTION
Fixes a building error on Power architecture:
  - `-march=native` on x86
  - `-mcpu=native` on Power