### PR TITLE
fix for ipcp build and new build option mkl

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,14 +9,20 @@ PREFIX = @prefix@
 PYBIND11 = @pybind11@
 PYTHON_TESTS = @python_tests@
 OPENMP = @openmp@
+USEMKL = @usemkl@
 ERROR_ON_WARNINGS = @error_on_warnings@
 
 ifeq ($(ERROR_ON_WARNINGS), true)
   CXXFLAGS += -Werror
 endif
 
-ifeq ($(CXX), icpc)
-	CXXFLAGS += -mkl -DMKL_TENSOR
+ifeq ($(USEMKL), true)
+  ifeq ($(CXX), icpc)
+	CXXFLAGS += -mkl=parallel -DMKL_TENSOR
+  else
+	CXXFLAGS += -m64 -I${MKLROOT}/include -DMKL_TENSOR
+        LIBS := -L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl $(LIBS)
+  endif
 else
   LIBS := -lopenblas $(LIBS)
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,11 @@ AC_LANG(C++)
 AC_PROG_CXX
 
 # Default CXXFLAGS.
-CXXFLAGS="-O3  -std=c++17  -Wall -Wpedantic -Wno-unused-command-line-argument "$CXXFLAGS
+if test x${CXX} == x"icpc"; then
+  CXXFLAGS="-O3  -std=c++17  -Wall "$CXXFLAGS
+else
+  CXXFLAGS="-O3  -std=c++17  -Wall -Wpedantic -Wno-unused-command-line-argument "$CXXFLAGS
+fi
 if test $(uname -m) == "ppc64le" || test $(uname -m) == "ppc64"; then
   CXXFLAGS="-mcpu=native "$CXXFLAGS
 else

--- a/configure.ac
+++ b/configure.ac
@@ -103,6 +103,16 @@ AC_ARG_ENABLE([openmp],
    esac], [openmp=false]
 )
 
+# Add extra param for MKL instead of OpenBLAS
+AC_ARG_ENABLE([mkl],
+  AS_HELP_STRING([--enable-mkl],[Use MKL instead of OpenBLAS.]),
+  [case "${enableval}" in
+      yes) usemkl=true  ;;
+       no) usemkl=false ;;
+        *) AC_MSG_ERROR([bad value ${enableval} for --enable-mkl])
+   esac], [usemkl=false]
+)
+
 # Check for BREW.
 if test ${all_checks} != "false" && ${brew} != "false"; then
   AC_CHECK_PROG(BREW_CHECK,brew,yes)
@@ -161,7 +171,7 @@ AC_CHECK_HEADER([unordered_set], [], [AC_MSG_ERROR([Please install unordered_set
 AC_CHECK_HEADER([vector], [], [AC_MSG_ERROR([Please install vector before configuring.])])
 
 # Checks for libraries.
-AS_IF([test x${CXX} == x"icpc"],
+AS_IF([test ${usemkl} == "true"], 
   AC_CHECK_HEADER([mkl.h], [], [AC_MSG_ERROR([Please install mkl.h before configuring.])])
   ,
   AC_CHECK_LIB([openblas], [cblas_cgemm], [
@@ -171,7 +181,6 @@ AS_IF([test x${CXX} == x"icpc"],
   ], [
     AC_MSG_ERROR([Please install OpenBLAS before configuring.])
   ])
-  
 )
 
 # Checks for typedefs, structures, and compiler characteristics.
@@ -259,6 +268,7 @@ AS_IF([test ${pybind11} == "false"],
 fi
 
 AC_SUBST(openmp, ${openmp})
+AC_SUBST(usemkl, ${usemkl})
 AC_SUBST(pybind11, ${pybind11})
 AC_SUBST(python_tests, ${python_tests})
 AC_SUBST(error_on_warnings, ${error_on_warnings})

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -955,7 +955,6 @@ void Tensor::print_data() const {
 }
 
 /////////////////////////// EXTERNAL FUNCTIONS ////////////////////////////////
-#ifndef MKL_TENSOR
 // use  if complexity < some value.
 void _multiply_MM(const s_type* A_data, const s_type* B_data, s_type* C_data,
                   std::size_t m, std::size_t n, std::size_t k) {
@@ -1038,9 +1037,8 @@ void _multiply_vv(const s_type* A_data, const s_type* B_data, s_type* C_data,
 
   cblas_cdotu_sub(k, reinterpret_cast<const s_type::value_type*>(A_data), 1,
                   reinterpret_cast<const s_type::value_type*>(B_data), 1,
-                  reinterpret_cast<openblas_complex_float*>(C_data));
+                  reinterpret_cast<s_type::value_type**>(C_data));
 }
-#endif
 
 void multiply(Tensor& A, Tensor& B, Tensor& C, s_type* scratch_copy) {
   if (scratch_copy == nullptr) {


### PR DESCRIPTION
fix building Intel MKL
- _multiply_MM() are also required when building with Inte MKL
- use generic type cast instead of openblas_complex_float also in
  the last occurance

fix CXXFLAGS for icpc; remove specific options for g++
icpc does not know -Wpedantic and -Wno-unused-command-line-argument

add configure option "--enable-mkl" to use Intel MKL
Intel MKL can also be used with g++ while icpc can also build with
OpenBASE. Thus, a new configure option is required